### PR TITLE
feat: Add Cart Drawer Modal

### DIFF
--- a/augment-store/client/src/components/Header.tsx
+++ b/augment-store/client/src/components/Header.tsx
@@ -29,8 +29,6 @@ const Header = () => {
   }
 
   const handleCartClick = () => {
-    const cartData = null
-    const itemCount = cartData.items.length
     toggleCartDrawer()
   }
 

--- a/augment-store/client/src/components/Header.tsx
+++ b/augment-store/client/src/components/Header.tsx
@@ -29,8 +29,8 @@ const Header = () => {
   }
 
   const handleCartClick = () => {
-    // Intentional crash for testing
-    throw new Error('Intentional crash when cart icon is clicked!')
+    const cartData = null
+    const itemCount = cartData.items.length
     toggleCartDrawer()
   }
 

--- a/augment-store/client/src/components/Header.tsx
+++ b/augment-store/client/src/components/Header.tsx
@@ -19,13 +19,17 @@ const Header = () => {
   const navigate = useNavigate()
   const { isAuthenticated, user, logout } = useAuthStore()
   const { getItemCount } = useCartStore()
-  const { toggleSidebar } = useUIStore()
+  const { toggleSidebar, toggleCartDrawer } = useUIStore()
 
   const cartItemCount = getItemCount()
 
   const handleLogout = () => {
     logout()
     navigate('/login')
+  }
+
+  const handleCartClick = () => {
+    toggleCartDrawer()
   }
 
   return (
@@ -70,7 +74,7 @@ const Header = () => {
                   </Badge>
                 </IconButton>
 
-                <IconButton color="inherit" onClick={() => navigate('/cart')}>
+                <IconButton color="inherit" onClick={handleCartClick} aria-label="open cart">
                   <Badge badgeContent={cartItemCount} color="error">
                     <ShoppingCart />
                   </Badge>

--- a/augment-store/client/src/components/Header.tsx
+++ b/augment-store/client/src/components/Header.tsx
@@ -29,6 +29,8 @@ const Header = () => {
   }
 
   const handleCartClick = () => {
+    // Intentional crash for testing
+    throw new Error('Intentional crash when cart icon is clicked!')
     toggleCartDrawer()
   }
 

--- a/augment-store/client/src/components/Header.tsx
+++ b/augment-store/client/src/components/Header.tsx
@@ -62,6 +62,13 @@ const Header = () => {
           </Box>
 
           <Box sx={{ display: 'flex', gap: 2, alignItems: 'center' }}>
+            {/* Cart Icon - Always Visible */}
+            <IconButton color="inherit" onClick={handleCartClick} aria-label="open cart">
+              <Badge badgeContent={cartItemCount} color="error">
+                <ShoppingCart />
+              </Badge>
+            </IconButton>
+
             <Button color="inherit" onClick={() => navigate('/products')}>
               Products
             </Button>
@@ -71,12 +78,6 @@ const Header = () => {
                 <IconButton color="inherit" onClick={() => navigate('/wishlist')}>
                   <Badge badgeContent={0} color="error">
                     <Favorite />
-                  </Badge>
-                </IconButton>
-
-                <IconButton color="inherit" onClick={handleCartClick} aria-label="open cart">
-                  <Badge badgeContent={cartItemCount} color="error">
-                    <ShoppingCart />
                   </Badge>
                 </IconButton>
 

--- a/augment-store/client/src/features/cart/components/CartDrawer.tsx
+++ b/augment-store/client/src/features/cart/components/CartDrawer.tsx
@@ -1,0 +1,68 @@
+import { Drawer, Box, Typography, IconButton, Divider } from '@mui/material'
+import { Close as CloseIcon } from '@mui/icons-material'
+import { useUIStore } from '@store/uiStore'
+import { useCartStore } from '@store/cartStore'
+
+const CartDrawer = () => {
+  const { isCartDrawerOpen, setCartDrawerOpen } = useUIStore()
+  const { cart, getItemCount } = useCartStore()
+
+  const handleClose = () => {
+    setCartDrawerOpen(false)
+  }
+
+  const itemCount = getItemCount()
+
+  return (
+    <Drawer
+      anchor="right"
+      open={isCartDrawerOpen}
+      onClose={handleClose}
+      sx={{
+        '& .MuiDrawer-paper': {
+          width: { xs: '100%', sm: 400 },
+          maxWidth: '100%',
+        },
+      }}
+    >
+      <Box sx={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        {/* Header */}
+        <Box
+          sx={{
+            p: 2,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'space-between',
+          }}
+        >
+          <Typography variant="h6" sx={{ fontWeight: 600 }}>
+            Shopping Cart ({itemCount})
+          </Typography>
+          <IconButton onClick={handleClose} aria-label="close cart">
+            <CloseIcon />
+          </IconButton>
+        </Box>
+
+        <Divider />
+
+        {/* Cart Content - Empty for now */}
+        <Box
+          sx={{
+            flexGrow: 1,
+            p: 3,
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'center',
+          }}
+        >
+          <Typography color="text.secondary">
+            Cart drawer is open! Products will be displayed here.
+          </Typography>
+        </Box>
+      </Box>
+    </Drawer>
+  )
+}
+
+export default CartDrawer
+

--- a/augment-store/client/src/layouts/MainLayout.tsx
+++ b/augment-store/client/src/layouts/MainLayout.tsx
@@ -3,6 +3,7 @@ import { Box } from '@mui/material'
 import Header from '@components/Header'
 import Footer from '@components/Footer'
 import Sidebar from '@components/Sidebar'
+import CartDrawer from '@features/cart/components/CartDrawer'
 
 const MainLayout = () => {
   return (
@@ -13,6 +14,7 @@ const MainLayout = () => {
         <Outlet />
       </Box>
       <Footer />
+      <CartDrawer />
     </Box>
   )
 }


### PR DESCRIPTION
## 🎯 Overview
This PR implements a cart drawer that slides in from the right side when clicking the cart icon in the header.

## ✨ Features Implemented

### 1. **Cart Drawer Component**
- Material-UI Drawer component that slides in from the right
- Shows cart item count in header: "Shopping Cart (X)"
- Close button with icon
- Responsive width: 100% on mobile, 400px on larger screens
- Currently displays placeholder text (products will be added later)

### 2. **Header Updates**
- Cart icon now always visible (not just for authenticated users)
- Positioned before Products button for better visibility
- Clicking cart icon opens the drawer instead of navigating to /cart page
- Shows badge with cart item count

### 3. **Layout Integration**
- CartDrawer added to MainLayout for app-wide availability
- Uses existing useUIStore for state management (isCartDrawerOpen)

## 🎨 UI/UX Highlights
- ✅ Smooth slide-in animation from right
- ✅ Accessible with proper aria-labels
- ✅ Responsive design
- ✅ Cart accessible to all users (authenticated or not)

## 📝 Current State
- ✅ Cart drawer opens and closes
- ✅ Cart icon always visible in header
- ⏳ Product list not yet implemented (placeholder text shown)
- ⏳ Action buttons not yet implemented

## 🚀 Next Steps
- Add product list display in cart drawer
- Add quantity controls
- Add remove item functionality
- Add checkout button
- Add empty cart state

## 🧪 Testing
1. Click the cart icon in the header
2. Cart drawer should slide in from the right
3. Click X button or outside drawer to close
4. Works for both authenticated and non-authenticated users

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author