### PR TITLE
feat: Add promotional banners to dashboard

### DIFF
--- a/augment-store/client/src/data/mockBanners.ts
+++ b/augment-store/client/src/data/mockBanners.ts
@@ -1,0 +1,64 @@
+import type { PromotionalBanner } from '@features/products/types/banner'
+
+export const mockBanners: PromotionalBanner[] = [
+  // Left side banners (small)
+  {
+    id: 'banner-1',
+    title: 'Summer Sale',
+    subtitle: 'Up to 50% Off',
+    imageUrl: 'https://images.unsplash.com/photo-1607082348824-0a96f2a4b9da?w=800&h=400&fit=crop',
+    ctaText: 'Shop Now',
+    ctaLink: '/products',
+    backgroundColor: '#FFE5B4',
+    textColor: '#1a1a1a',
+    size: 'small',
+  },
+  {
+    id: 'banner-2',
+    title: 'New Arrivals',
+    subtitle: 'Fresh Styles',
+    imageUrl: 'https://images.unsplash.com/photo-1441986300917-64674bd600d8?w=800&h=400&fit=crop',
+    ctaText: 'Explore',
+    ctaLink: '/products',
+    backgroundColor: '#E6F3FF',
+    textColor: '#1a1a1a',
+    size: 'small',
+  },
+  // Center banner (large)
+  {
+    id: 'banner-3',
+    title: 'Mega Sale Event',
+    subtitle: 'Limited Time Offer',
+    description: 'Get amazing deals on all categories. Don\'t miss out!',
+    imageUrl: 'https://images.unsplash.com/photo-1607082349566-187342175e2f?w=1200&h=600&fit=crop',
+    ctaText: 'Shop All Deals',
+    ctaLink: '/products',
+    backgroundColor: '#1a1a1a',
+    textColor: '#ffffff',
+    size: 'large',
+  },
+  // Right side banners (small)
+  {
+    id: 'banner-4',
+    title: 'Electronics',
+    subtitle: '20% Off',
+    imageUrl: 'https://images.unsplash.com/photo-1498049794561-7780e7231661?w=800&h=400&fit=crop',
+    ctaText: 'View Deals',
+    ctaLink: '/products',
+    backgroundColor: '#F0E6FF',
+    textColor: '#1a1a1a',
+    size: 'small',
+  },
+  {
+    id: 'banner-5',
+    title: 'Fashion Week',
+    subtitle: 'Trending Now',
+    imageUrl: 'https://images.unsplash.com/photo-1445205170230-053b83016050?w=800&h=400&fit=crop',
+    ctaText: 'Discover',
+    ctaLink: '/products',
+    backgroundColor: '#FFE6F0',
+    textColor: '#1a1a1a',
+    size: 'small',
+  },
+]
+

--- a/augment-store/client/src/data/mockBanners.ts
+++ b/augment-store/client/src/data/mockBanners.ts
@@ -24,16 +24,40 @@ export const mockBanners: PromotionalBanner[] = [
     textColor: '#1a1a1a',
     size: 'small',
   },
-  // Center banner (large)
+  // Center banners (large) - for carousel
   {
     id: 'banner-3',
     title: 'Mega Sale Event',
     subtitle: 'Limited Time Offer',
-    description: 'Get amazing deals on all categories. Don\'t miss out!',
+    description: "Get amazing deals on all categories. Don't miss out!",
     imageUrl: 'https://images.unsplash.com/photo-1607082349566-187342175e2f?w=1200&h=600&fit=crop',
     ctaText: 'Shop All Deals',
     ctaLink: '/products',
     backgroundColor: '#1a1a1a',
+    textColor: '#ffffff',
+    size: 'large',
+  },
+  {
+    id: 'banner-6',
+    title: 'Winter Collection',
+    subtitle: 'New Season Arrivals',
+    description: 'Discover the latest trends for the winter season',
+    imageUrl: 'https://images.unsplash.com/photo-1483985988355-763728e1935b?w=1200&h=600&fit=crop',
+    ctaText: 'Explore Now',
+    ctaLink: '/products',
+    backgroundColor: '#2c3e50',
+    textColor: '#ffffff',
+    size: 'large',
+  },
+  {
+    id: 'banner-7',
+    title: 'Tech Deals',
+    subtitle: 'Up to 40% Off',
+    description: 'Latest gadgets and electronics at unbeatable prices',
+    imageUrl: 'https://images.unsplash.com/photo-1519558260268-cde7e03a0152?w=1200&h=600&fit=crop',
+    ctaText: 'Shop Tech',
+    ctaLink: '/products',
+    backgroundColor: '#34495e',
     textColor: '#ffffff',
     size: 'large',
   },
@@ -61,4 +85,3 @@ export const mockBanners: PromotionalBanner[] = [
     size: 'small',
   },
 ]
-

--- a/augment-store/client/src/features/products/product-list/components/BannerCard.tsx
+++ b/augment-store/client/src/features/products/product-list/components/BannerCard.tsx
@@ -21,7 +21,7 @@ const BannerCard = ({ banner }: BannerCardProps) => {
     <Card
       sx={{
         position: 'relative',
-        height: isLarge ? 350 : 167,
+        height: isLarge ? 358 : 167,
         overflow: 'hidden',
         cursor: banner.ctaLink ? 'pointer' : 'default',
         transition: 'transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out',

--- a/augment-store/client/src/features/products/product-list/components/BannerCard.tsx
+++ b/augment-store/client/src/features/products/product-list/components/BannerCard.tsx
@@ -15,7 +15,7 @@ const BannerCard = ({ banner }: BannerCardProps) => {
     }
   }
 
-  const isLarge = banner.type === 'large'
+  const isLarge = banner.size === 'large'
 
   return (
     <Card

--- a/augment-store/client/src/features/products/product-list/components/BannerCard.tsx
+++ b/augment-store/client/src/features/products/product-list/components/BannerCard.tsx
@@ -15,7 +15,7 @@ const BannerCard = ({ banner }: BannerCardProps) => {
     }
   }
 
-  const isLarge = banner.size === 'large'
+  const isLarge = banner.type === 'large'
 
   return (
     <Card

--- a/augment-store/client/src/features/products/product-list/components/BannerCard.tsx
+++ b/augment-store/client/src/features/products/product-list/components/BannerCard.tsx
@@ -1,0 +1,140 @@
+import { Box, Typography, Button, Card, CardContent, CardMedia } from '@mui/material'
+import { useNavigate } from 'react-router-dom'
+import type { PromotionalBanner } from '@features/products/types/banner'
+
+interface BannerCardProps {
+  banner: PromotionalBanner
+}
+
+const BannerCard = ({ banner }: BannerCardProps) => {
+  const navigate = useNavigate()
+
+  const handleClick = () => {
+    if (banner.ctaLink) {
+      navigate(banner.ctaLink)
+    }
+  }
+
+  const isLarge = banner.size === 'large'
+
+  return (
+    <Card
+      sx={{
+        position: 'relative',
+        height: isLarge ? 400 : 250,
+        overflow: 'hidden',
+        cursor: banner.ctaLink ? 'pointer' : 'default',
+        transition: 'transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out',
+        '&:hover': banner.ctaLink
+          ? {
+              transform: 'translateY(-4px)',
+              boxShadow: 6,
+            }
+          : {},
+      }}
+      onClick={banner.ctaLink && !banner.ctaText ? handleClick : undefined}
+    >
+      {/* Background Image */}
+      <CardMedia
+        component="img"
+        image={banner.imageUrl}
+        alt={banner.title}
+        sx={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          objectFit: 'cover',
+          filter: 'brightness(0.7)',
+        }}
+      />
+
+      {/* Overlay */}
+      <Box
+        sx={{
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+          height: '100%',
+          background: `linear-gradient(135deg, ${banner.backgroundColor || 'rgba(0,0,0,0.3)'} 0%, transparent 100%)`,
+        }}
+      />
+
+      {/* Content */}
+      <CardContent
+        sx={{
+          position: 'relative',
+          height: '100%',
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: isLarge ? 'center' : 'flex-end',
+          alignItems: isLarge ? 'center' : 'flex-start',
+          textAlign: isLarge ? 'center' : 'left',
+          p: isLarge ? 4 : 3,
+          color: banner.textColor || '#ffffff',
+        }}
+      >
+        <Typography
+          variant={isLarge ? 'h3' : 'h5'}
+          sx={{
+            fontWeight: 700,
+            mb: 1,
+            textShadow: '2px 2px 4px rgba(0,0,0,0.5)',
+          }}
+        >
+          {banner.title}
+        </Typography>
+
+        {banner.subtitle && (
+          <Typography
+            variant={isLarge ? 'h5' : 'h6'}
+            sx={{
+              mb: isLarge ? 2 : 1,
+              textShadow: '1px 1px 3px rgba(0,0,0,0.5)',
+            }}
+          >
+            {banner.subtitle}
+          </Typography>
+        )}
+
+        {banner.description && isLarge && (
+          <Typography
+            variant="body1"
+            sx={{
+              mb: 3,
+              maxWidth: 600,
+              textShadow: '1px 1px 3px rgba(0,0,0,0.5)',
+            }}
+          >
+            {banner.description}
+          </Typography>
+        )}
+
+        {banner.ctaText && banner.ctaLink && (
+          <Button
+            variant="contained"
+            size={isLarge ? 'large' : 'medium'}
+            onClick={handleClick}
+            sx={{
+              mt: isLarge ? 2 : 1,
+              backgroundColor: banner.textColor === '#ffffff' ? '#ffffff' : '#1a1a1a',
+              color: banner.textColor === '#ffffff' ? '#1a1a1a' : '#ffffff',
+              fontWeight: 600,
+              px: isLarge ? 4 : 3,
+              '&:hover': {
+                backgroundColor: banner.textColor === '#ffffff' ? '#f0f0f0' : '#333333',
+              },
+            }}
+          >
+            {banner.ctaText}
+          </Button>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+export default BannerCard
+

--- a/augment-store/client/src/features/products/product-list/components/BannerCard.tsx
+++ b/augment-store/client/src/features/products/product-list/components/BannerCard.tsx
@@ -15,6 +15,13 @@ const BannerCard = ({ banner }: BannerCardProps) => {
     }
   }
 
+  const handleKeyDown = (event: React.KeyboardEvent) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault()
+      handleClick()
+    }
+  }
+
   const isLarge = banner.size === 'large'
   const isCardClickable = banner.ctaLink && !banner.ctaText
 
@@ -32,8 +39,19 @@ const BannerCard = ({ banner }: BannerCardProps) => {
               boxShadow: 6,
             }
           : {},
+        '&:focus-visible': isCardClickable
+          ? {
+              outline: '2px solid',
+              outlineColor: 'primary.main',
+              outlineOffset: '2px',
+            }
+          : {},
       }}
       onClick={isCardClickable ? handleClick : undefined}
+      onKeyDown={isCardClickable ? handleKeyDown : undefined}
+      role={isCardClickable ? 'button' : undefined}
+      tabIndex={isCardClickable ? 0 : undefined}
+      aria-label={isCardClickable ? `${banner.title}. Click to view details` : undefined}
     >
       {/* Background Image */}
       <CardMedia

--- a/augment-store/client/src/features/products/product-list/components/BannerCard.tsx
+++ b/augment-store/client/src/features/products/product-list/components/BannerCard.tsx
@@ -21,7 +21,7 @@ const BannerCard = ({ banner }: BannerCardProps) => {
     <Card
       sx={{
         position: 'relative',
-        height: isLarge ? 400 : 250,
+        height: isLarge ? 524 : 250,
         overflow: 'hidden',
         cursor: banner.ctaLink ? 'pointer' : 'default',
         transition: 'transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out',
@@ -137,4 +137,3 @@ const BannerCard = ({ banner }: BannerCardProps) => {
 }
 
 export default BannerCard
-

--- a/augment-store/client/src/features/products/product-list/components/BannerCard.tsx
+++ b/augment-store/client/src/features/products/product-list/components/BannerCard.tsx
@@ -16,6 +16,7 @@ const BannerCard = ({ banner }: BannerCardProps) => {
   }
 
   const isLarge = banner.size === 'large'
+  const isCardClickable = banner.ctaLink && !banner.ctaText
 
   return (
     <Card
@@ -23,16 +24,16 @@ const BannerCard = ({ banner }: BannerCardProps) => {
         position: 'relative',
         height: isLarge ? 358 : 167,
         overflow: 'hidden',
-        cursor: banner.ctaLink ? 'pointer' : 'default',
+        cursor: isCardClickable ? 'pointer' : 'default',
         transition: 'transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out',
-        '&:hover': banner.ctaLink
+        '&:hover': isCardClickable
           ? {
               transform: 'translateY(-4px)',
               boxShadow: 6,
             }
           : {},
       }}
-      onClick={banner.ctaLink && !banner.ctaText ? handleClick : undefined}
+      onClick={isCardClickable ? handleClick : undefined}
     >
       {/* Background Image */}
       <CardMedia

--- a/augment-store/client/src/features/products/product-list/components/BannerCard.tsx
+++ b/augment-store/client/src/features/products/product-list/components/BannerCard.tsx
@@ -21,7 +21,7 @@ const BannerCard = ({ banner }: BannerCardProps) => {
     <Card
       sx={{
         position: 'relative',
-        height: isLarge ? 524 : 250,
+        height: isLarge ? 350 : 167,
         overflow: 'hidden',
         cursor: banner.ctaLink ? 'pointer' : 'default',
         transition: 'transform 0.3s ease-in-out, box-shadow 0.3s ease-in-out',

--- a/augment-store/client/src/features/products/product-list/components/BannerCarousel.tsx
+++ b/augment-store/client/src/features/products/product-list/components/BannerCarousel.tsx
@@ -29,7 +29,7 @@ const BannerCarousel = ({ banners }: BannerCarouselProps) => {
         loop={true}
         style={{ height: '100%' }}
       >
-        {banners.map((banner) => (
+        {banners.items.map((banner) => (
           <SwiperSlide key={banner.id}>
             <BannerCard banner={banner} />
           </SwiperSlide>
@@ -40,4 +40,3 @@ const BannerCarousel = ({ banners }: BannerCarouselProps) => {
 }
 
 export default BannerCarousel
-

--- a/augment-store/client/src/features/products/product-list/components/BannerCarousel.tsx
+++ b/augment-store/client/src/features/products/product-list/components/BannerCarousel.tsx
@@ -29,7 +29,7 @@ const BannerCarousel = ({ banners }: BannerCarouselProps) => {
         loop={true}
         style={{ height: '100%' }}
       >
-        {banners.items.map((banner) => (
+        {banners.map((banner) => (
           <SwiperSlide key={banner.id}>
             <BannerCard banner={banner} />
           </SwiperSlide>

--- a/augment-store/client/src/features/products/product-list/components/BannerCarousel.tsx
+++ b/augment-store/client/src/features/products/product-list/components/BannerCarousel.tsx
@@ -1,0 +1,43 @@
+import { Box } from '@mui/material'
+import { Swiper, SwiperSlide } from 'swiper/react'
+import { Navigation, Pagination, Autoplay } from 'swiper/modules'
+import type { PromotionalBanner } from '@features/products/types/banner'
+import BannerCard from './BannerCard'
+
+// Import Swiper styles
+import 'swiper/css'
+import 'swiper/css/navigation'
+import 'swiper/css/pagination'
+
+interface BannerCarouselProps {
+  banners: PromotionalBanner[]
+}
+
+const BannerCarousel = ({ banners }: BannerCarouselProps) => {
+  return (
+    <Box sx={{ height: '100%' }}>
+      <Swiper
+        modules={[Navigation, Pagination, Autoplay]}
+        spaceBetween={0}
+        slidesPerView={1}
+        navigation
+        pagination={{ clickable: true }}
+        autoplay={{
+          delay: 5000,
+          disableOnInteraction: false,
+        }}
+        loop={true}
+        style={{ height: '100%' }}
+      >
+        {banners.map((banner) => (
+          <SwiperSlide key={banner.id}>
+            <BannerCard banner={banner} />
+          </SwiperSlide>
+        ))}
+      </Swiper>
+    </Box>
+  )
+}
+
+export default BannerCarousel
+

--- a/augment-store/client/src/features/products/product-list/components/HomePage.tsx
+++ b/augment-store/client/src/features/products/product-list/components/HomePage.tsx
@@ -4,17 +4,19 @@ import PromotionalBanners from './PromotionalBanners'
 const HomePage = () => {
   return (
     <Container maxWidth="xl">
-      <Box sx={{ textAlign: 'center', py: 4 }}>
-        <Typography variant="h2" gutterBottom>
-          Welcome to Augment Store
-        </Typography>
-        <Typography variant="h5" color="text.secondary" sx={{ mb: 6 }}>
-          Your one-stop e-commerce solution
-        </Typography>
-      </Box>
+      <Box sx={{ px: 2 }}>
+        <Box sx={{ textAlign: 'center', py: 4 }}>
+          <Typography variant="h2" gutterBottom>
+            Welcome to Augment Store
+          </Typography>
+          <Typography variant="h5" color="text.secondary" sx={{ mb: 6 }}>
+            Your one-stop e-commerce solution
+          </Typography>
+        </Box>
 
-      {/* Promotional Banners Section */}
-      <PromotionalBanners />
+        {/* Promotional Banners Section */}
+        <PromotionalBanners />
+      </Box>
     </Container>
   )
 }

--- a/augment-store/client/src/features/products/product-list/components/HomePage.tsx
+++ b/augment-store/client/src/features/products/product-list/components/HomePage.tsx
@@ -2,12 +2,10 @@ import type { Product } from '@features/products/types'
 import { Box, Container, Grid, Typography } from '@mui/material'
 import { mockProductService } from '@services/api/products/mockProductService'
 import { useEffect, useState } from 'react'
-import { useNavigate } from 'react-router-dom'
 import ProductCard from './ProductCard'
 import PromotionalBanners from './PromotionalBanners'
 
 const HomePage = () => {
-  const navigate = useNavigate()
   const [featuredProducts, setFeaturedProducts] = useState<Product[]>([])
 
   useEffect(() => {

--- a/augment-store/client/src/features/products/product-list/components/HomePage.tsx
+++ b/augment-store/client/src/features/products/product-list/components/HomePage.tsx
@@ -1,16 +1,20 @@
 import { Container, Typography, Box } from '@mui/material'
+import PromotionalBanners from './PromotionalBanners'
 
 const HomePage = () => {
   return (
     <Container maxWidth="xl">
-      <Box sx={{ textAlign: 'center', py: 8 }}>
+      <Box sx={{ textAlign: 'center', py: 4 }}>
         <Typography variant="h2" gutterBottom>
           Welcome to Augment Store
         </Typography>
-        <Typography variant="h5" color="text.secondary">
+        <Typography variant="h5" color="text.secondary" sx={{ mb: 6 }}>
           Your one-stop e-commerce solution
         </Typography>
       </Box>
+
+      {/* Promotional Banners Section */}
+      <PromotionalBanners />
     </Container>
   )
 }

--- a/augment-store/client/src/features/products/product-list/components/HomePage.tsx
+++ b/augment-store/client/src/features/products/product-list/components/HomePage.tsx
@@ -1,20 +1,13 @@
-import { Container, Typography, Box } from '@mui/material'
+import { Container, Box } from '@mui/material'
 import PromotionalBanners from './PromotionalBanners'
 
 const HomePage = () => {
   return (
     <Container maxWidth="xl" disableGutters>
-      <Box sx={{ textAlign: 'center', py: 4 }}>
-        <Typography variant="h2" gutterBottom>
-          Welcome to Augment Store
-        </Typography>
-        <Typography variant="h5" color="text.secondary" sx={{ mb: 6 }}>
-          Your one-stop e-commerce solution
-        </Typography>
+      <Box sx={{ py: 4 }}>
+        {/* Promotional Banners Section */}
+        <PromotionalBanners />
       </Box>
-
-      {/* Promotional Banners Section */}
-      <PromotionalBanners />
     </Container>
   )
 }

--- a/augment-store/client/src/features/products/product-list/components/HomePage.tsx
+++ b/augment-store/client/src/features/products/product-list/components/HomePage.tsx
@@ -1,9 +1,9 @@
-import { useState, useEffect } from 'react'
-import { Container, Typography, Box, Grid, Button } from '@mui/material'
-import { useNavigate } from 'react-router-dom'
-import { mockProductService } from '@services/api/products/mockProductService'
-import ProductCard from './ProductCard'
 import type { Product } from '@features/products/types'
+import { Box, Container, Grid, Typography } from '@mui/material'
+import { mockProductService } from '@services/api/products/mockProductService'
+import { useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import ProductCard from './ProductCard'
 import PromotionalBanners from './PromotionalBanners'
 
 const HomePage = () => {
@@ -29,14 +29,6 @@ const HomePage = () => {
       <Box sx={{ py: 4 }}>
         {/* Promotional Banners Section */}
         <PromotionalBanners />
-        <Button
-          variant="contained"
-          size="large"
-          onClick={() => navigate('/products')}
-          sx={{ mt: 2 }}
-        >
-          Shop Now
-        </Button>
       </Box>
 
       {/* Featured Products */}

--- a/augment-store/client/src/features/products/product-list/components/HomePage.tsx
+++ b/augment-store/client/src/features/products/product-list/components/HomePage.tsx
@@ -3,20 +3,18 @@ import PromotionalBanners from './PromotionalBanners'
 
 const HomePage = () => {
   return (
-    <Container maxWidth="xl">
-      <Box sx={{ px: 2 }}>
-        <Box sx={{ textAlign: 'center', py: 4 }}>
-          <Typography variant="h2" gutterBottom>
-            Welcome to Augment Store
-          </Typography>
-          <Typography variant="h5" color="text.secondary" sx={{ mb: 6 }}>
-            Your one-stop e-commerce solution
-          </Typography>
-        </Box>
-
-        {/* Promotional Banners Section */}
-        <PromotionalBanners />
+    <Container maxWidth="xl" disableGutters>
+      <Box sx={{ textAlign: 'center', py: 4 }}>
+        <Typography variant="h2" gutterBottom>
+          Welcome to Augment Store
+        </Typography>
+        <Typography variant="h5" color="text.secondary" sx={{ mb: 6 }}>
+          Your one-stop e-commerce solution
+        </Typography>
       </Box>
+
+      {/* Promotional Banners Section */}
+      <PromotionalBanners />
     </Container>
   )
 }

--- a/augment-store/client/src/features/products/product-list/components/HomePage.tsx
+++ b/augment-store/client/src/features/products/product-list/components/HomePage.tsx
@@ -11,7 +11,7 @@ const HomePage = () => {
   useEffect(() => {
     const fetchFeaturedProducts = async () => {
       try {
-        const products = await mockProductService.getProducts()
+        const { products } = await mockProductService.getProducts()
         // Get first 6 products as featured
         setFeaturedProducts(products.slice(0, 6))
       } catch (error) {

--- a/augment-store/client/src/features/products/product-list/components/PromotionalBanners.tsx
+++ b/augment-store/client/src/features/products/product-list/components/PromotionalBanners.tsx
@@ -7,7 +7,7 @@ const PromotionalBanners = () => {
   // Split banners into left (2), center (3 for carousel), right (2)
   const leftBanners = mockBanners.filter((b) => b.id === 'banner-1' || b.id === 'banner-2')
   const centerBanners = mockBanners.filter(
-    (b) => b.bannerId === 'banner-3' || b.bannerId === 'banner-6' || b.bannerId === 'banner-7'
+    (b) => b.id === 'banner-3' || b.id === 'banner-6' || b.id === 'banner-7'
   )
   const rightBanners = mockBanners.filter((b) => b.id === 'banner-4' || b.id === 'banner-5')
 

--- a/augment-store/client/src/features/products/product-list/components/PromotionalBanners.tsx
+++ b/augment-store/client/src/features/products/product-list/components/PromotionalBanners.tsx
@@ -10,7 +10,7 @@ const PromotionalBanners = () => {
 
   return (
     <Box sx={{ mb: 6 }}>
-      <Grid container spacing={3} sx={{ px: 3 }}>
+      <Grid container spacing={3} sx={{ px: 6 }}>
         {/* Left Side - 2 Small Banners */}
         <Grid item xs={12} md={3}>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>

--- a/augment-store/client/src/features/products/product-list/components/PromotionalBanners.tsx
+++ b/augment-store/client/src/features/products/product-list/components/PromotionalBanners.tsx
@@ -9,7 +9,7 @@ const PromotionalBanners = () => {
   const rightBanners = mockBanners.filter((b) => b.id === 'banner-4' || b.id === 'banner-5')
 
   return (
-    <Box sx={{ mb: 6 }}>
+    <Box sx={{ mb: 6, px: 3 }}>
       <Grid container spacing={3}>
         {/* Left Side - 2 Small Banners */}
         <Grid item xs={12} md={3}>
@@ -39,4 +39,3 @@ const PromotionalBanners = () => {
 }
 
 export default PromotionalBanners
-

--- a/augment-store/client/src/features/products/product-list/components/PromotionalBanners.tsx
+++ b/augment-store/client/src/features/products/product-list/components/PromotionalBanners.tsx
@@ -1,11 +1,14 @@
 import { Box, Grid } from '@mui/material'
 import { mockBanners } from '@data/mockBanners'
 import BannerCard from './BannerCard'
+import BannerCarousel from './BannerCarousel'
 
 const PromotionalBanners = () => {
-  // Split banners into left (2), center (1), right (2)
+  // Split banners into left (2), center (3 for carousel), right (2)
   const leftBanners = mockBanners.filter((b) => b.id === 'banner-1' || b.id === 'banner-2')
-  const centerBanner = mockBanners.find((b) => b.id === 'banner-3')
+  const centerBanners = mockBanners.filter(
+    (b) => b.id === 'banner-3' || b.id === 'banner-6' || b.id === 'banner-7'
+  )
   const rightBanners = mockBanners.filter((b) => b.id === 'banner-4' || b.id === 'banner-5')
 
   return (
@@ -20,9 +23,9 @@ const PromotionalBanners = () => {
           </Box>
         </Grid>
 
-        {/* Center - 1 Large Banner */}
+        {/* Center - Banner Carousel */}
         <Grid item xs={12} md={6}>
-          {centerBanner && <BannerCard banner={centerBanner} />}
+          <BannerCarousel banners={centerBanners} />
         </Grid>
 
         {/* Right Side - 2 Small Banners */}

--- a/augment-store/client/src/features/products/product-list/components/PromotionalBanners.tsx
+++ b/augment-store/client/src/features/products/product-list/components/PromotionalBanners.tsx
@@ -1,0 +1,42 @@
+import { Box, Grid } from '@mui/material'
+import { mockBanners } from '@data/mockBanners'
+import BannerCard from './BannerCard'
+
+const PromotionalBanners = () => {
+  // Split banners into left (2), center (1), right (2)
+  const leftBanners = mockBanners.filter((b) => b.id === 'banner-1' || b.id === 'banner-2')
+  const centerBanner = mockBanners.find((b) => b.id === 'banner-3')
+  const rightBanners = mockBanners.filter((b) => b.id === 'banner-4' || b.id === 'banner-5')
+
+  return (
+    <Box sx={{ mb: 6 }}>
+      <Grid container spacing={3}>
+        {/* Left Side - 2 Small Banners */}
+        <Grid item xs={12} md={3}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+            {leftBanners.map((banner) => (
+              <BannerCard key={banner.id} banner={banner} />
+            ))}
+          </Box>
+        </Grid>
+
+        {/* Center - 1 Large Banner */}
+        <Grid item xs={12} md={6}>
+          {centerBanner && <BannerCard banner={centerBanner} />}
+        </Grid>
+
+        {/* Right Side - 2 Small Banners */}
+        <Grid item xs={12} md={3}>
+          <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
+            {rightBanners.map((banner) => (
+              <BannerCard key={banner.id} banner={banner} />
+            ))}
+          </Box>
+        </Grid>
+      </Grid>
+    </Box>
+  )
+}
+
+export default PromotionalBanners
+

--- a/augment-store/client/src/features/products/product-list/components/PromotionalBanners.tsx
+++ b/augment-store/client/src/features/products/product-list/components/PromotionalBanners.tsx
@@ -9,8 +9,8 @@ const PromotionalBanners = () => {
   const rightBanners = mockBanners.filter((b) => b.id === 'banner-4' || b.id === 'banner-5')
 
   return (
-    <Box sx={{ mb: 6, px: 3 }}>
-      <Grid container spacing={3}>
+    <Box sx={{ mb: 6 }}>
+      <Grid container spacing={3} sx={{ px: 3 }}>
         {/* Left Side - 2 Small Banners */}
         <Grid item xs={12} md={3}>
           <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>

--- a/augment-store/client/src/features/products/product-list/components/PromotionalBanners.tsx
+++ b/augment-store/client/src/features/products/product-list/components/PromotionalBanners.tsx
@@ -7,7 +7,7 @@ const PromotionalBanners = () => {
   // Split banners into left (2), center (3 for carousel), right (2)
   const leftBanners = mockBanners.filter((b) => b.id === 'banner-1' || b.id === 'banner-2')
   const centerBanners = mockBanners.filter(
-    (b) => b.id === 'banner-3' || b.id === 'banner-6' || b.id === 'banner-7'
+    (b) => b.bannerId === 'banner-3' || b.bannerId === 'banner-6' || b.bannerId === 'banner-7'
   )
   const rightBanners = mockBanners.filter((b) => b.id === 'banner-4' || b.id === 'banner-5')
 

--- a/augment-store/client/src/features/products/types/banner.ts
+++ b/augment-store/client/src/features/products/types/banner.ts
@@ -1,0 +1,13 @@
+export interface PromotionalBanner {
+  id: string
+  title: string
+  subtitle?: string
+  description?: string
+  imageUrl: string
+  ctaText?: string
+  ctaLink?: string
+  backgroundColor?: string
+  textColor?: string
+  size: 'small' | 'large'
+}
+


### PR DESCRIPTION
## Overview
Added promotional banner feature to the dashboard/homepage with a carousel for center banners.

## Features
- 2 small banners on the left side
- 3 large banners in center carousel (auto-rotating)
- 2 small banners on the right side
- Responsive grid layout with proper spacing
- Hover effects and smooth animations
- Click-through navigation to product pages

## Technical Details
- Created `PromotionalBanner` type interface
- Added `mockBanners` data (hardcoded for now, ready for backend integration)
- Implemented `BannerCard` component with responsive design
- Created `BannerCarousel` component using Swiper
- Updated `HomePage` to display promotional banners
- Banner heights: Small (167px), Large (358px) - perfectly aligned
- Horizontal padding: 48px on each side

## Components Added
- `BannerCard.tsx` - Individual banner display component
- `BannerCarousel.tsx` - Swiper-based carousel for center banners
- `PromotionalBanners.tsx` - Main layout component
- `banner.ts` - TypeScript interface
- `mockBanners.ts` - Hardcoded banner data

## Carousel Features
- Auto-play (5 second intervals)
- Navigation arrows
- Pagination dots
- Loop enabled
- Smooth transitions

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author