### PR TITLE
feat: Implement price filtering with min/max input fields

### DIFF
--- a/augment-store/client/src/features/products/product-list/components/PriceRangeFilter.tsx
+++ b/augment-store/client/src/features/products/product-list/components/PriceRangeFilter.tsx
@@ -1,5 +1,5 @@
-import { useState, useEffect, SyntheticEvent } from 'react'
-import { Box, Typography, Slider } from '@mui/material'
+import { useState, useEffect } from 'react'
+import { Box, Typography, TextField, InputAdornment } from '@mui/material'
 
 interface PriceRangeFilterProps {
   minPrice: number
@@ -9,19 +9,81 @@ interface PriceRangeFilterProps {
 }
 
 const PriceRangeFilter = ({ minPrice, maxPrice, value, onChange }: PriceRangeFilterProps) => {
-  const [localValue, setLocalValue] = useState<[number, number]>(value)
+  const [localMinPrice, setLocalMinPrice] = useState<string>(value[0].toString())
+  const [localMaxPrice, setLocalMaxPrice] = useState<string>(value[1].toString())
+  const [minPriceError, setMinPriceError] = useState<string>('')
+  const [maxPriceError, setMaxPriceError] = useState<string>('')
 
-  // Update local value when prop changes (e.g., reset filters)
+  // Update local values when prop changes (e.g., reset filters)
   useEffect(() => {
-    setLocalValue(value)
+    setLocalMinPrice(value[0].toString())
+    setLocalMaxPrice(value[1].toString())
+    setMinPriceError('')
+    setMaxPriceError('')
   }, [value])
 
-  const handleChange = (_event: Event, newValue: number | number[]) => {
-    setLocalValue(newValue as [number, number])
+  const validateAndUpdate = (newMinPrice: string, newMaxPrice: string) => {
+    const minVal = parseFloat(newMinPrice)
+    const maxVal = parseFloat(newMaxPrice)
+
+    let hasError = false
+
+    // Validate min price
+    if (newMinPrice === '' || isNaN(minVal)) {
+      setMinPriceError('Please enter a valid price')
+      hasError = true
+    } else if (minVal < 0) {
+      setMinPriceError('Price cannot be negative')
+      hasError = true
+    } else {
+      setMinPriceError('')
+    }
+
+    // Validate max price
+    if (newMaxPrice === '' || isNaN(maxVal)) {
+      setMaxPriceError('Please enter a valid price')
+      hasError = true
+    } else if (maxVal < 0) {
+      setMaxPriceError('Price cannot be negative')
+      hasError = true
+    } else {
+      setMaxPriceError('')
+    }
+
+    // Validate min <= max
+    if (!hasError && minVal > maxVal) {
+      setMinPriceError('Min price cannot be greater than max price')
+      hasError = true
+    }
+
+    // If no errors, update parent
+    if (!hasError) {
+      onChange([minVal, maxVal])
+    }
   }
 
-  const handleChangeCommitted = (_event: Event | SyntheticEvent, newValue: number | number[]) => {
-    onChange(newValue as [number, number])
+  const handleMinPriceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.value
+    setLocalMinPrice(newValue)
+  }
+
+  const handleMaxPriceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const newValue = event.target.value
+    setLocalMaxPrice(newValue)
+  }
+
+  const handleMinPriceBlur = () => {
+    validateAndUpdate(localMinPrice, localMaxPrice)
+  }
+
+  const handleMaxPriceBlur = () => {
+    validateAndUpdate(localMinPrice, localMaxPrice)
+  }
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    if (event.key === 'Enter') {
+      validateAndUpdate(localMinPrice, localMaxPrice)
+    }
   }
 
   return (
@@ -30,43 +92,41 @@ const PriceRangeFilter = ({ minPrice, maxPrice, value, onChange }: PriceRangeFil
         Price Range
       </Typography>
       <Box sx={{ px: 2, py: 1 }}>
-        <Slider
-          value={localValue}
-          onChange={handleChange}
-          onChangeCommitted={handleChangeCommitted}
-          valueLabelDisplay="auto"
-          valueLabelFormat={(value) => `$${value}`}
-          min={minPrice}
-          max={maxPrice}
-          step={1}
-          disableSwap
-          sx={{
-            '& .MuiSlider-thumb': {
-              width: 20,
-              height: 20,
-              '&:hover, &.Mui-focusVisible': {
-                boxShadow: '0 0 0 8px rgba(25, 118, 210, 0.16)',
-              },
-              '&.Mui-active': {
-                boxShadow: '0 0 0 14px rgba(25, 118, 210, 0.16)',
-              },
-            },
-            '& .MuiSlider-track': {
-              height: 4,
-            },
-            '& .MuiSlider-rail': {
-              height: 4,
-              opacity: 0.3,
-            },
-          }}
-        />
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 1 }}>
-          <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 500 }}>
-            ${localValue[0].toFixed(2)}
-          </Typography>
-          <Typography variant="body2" color="text.secondary" sx={{ fontWeight: 500 }}>
-            ${localValue[1].toFixed(2)}
-          </Typography>
+        <Box sx={{ display: 'flex', gap: 2, alignItems: 'flex-start' }}>
+          <TextField
+            label="Min Price"
+            type="number"
+            value={localMinPrice}
+            onChange={handleMinPriceChange}
+            onBlur={handleMinPriceBlur}
+            onKeyDown={handleKeyDown}
+            error={!!minPriceError}
+            helperText={minPriceError}
+            size="small"
+            fullWidth
+            InputProps={{
+              startAdornment: <InputAdornment position="start">$</InputAdornment>,
+              inputProps: { min: 0, step: 0.01 },
+            }}
+            aria-label="Minimum price"
+          />
+          <TextField
+            label="Max Price"
+            type="number"
+            value={localMaxPrice}
+            onChange={handleMaxPriceChange}
+            onBlur={handleMaxPriceBlur}
+            onKeyDown={handleKeyDown}
+            error={!!maxPriceError}
+            helperText={maxPriceError}
+            size="small"
+            fullWidth
+            InputProps={{
+              startAdornment: <InputAdornment position="start">$</InputAdornment>,
+              inputProps: { min: 0, step: 0.01 },
+            }}
+            aria-label="Maximum price"
+          />
         </Box>
       </Box>
     </Box>

--- a/augment-store/client/src/features/products/product-list/components/PriceRangeFilter.tsx
+++ b/augment-store/client/src/features/products/product-list/components/PriceRangeFilter.tsx
@@ -8,7 +8,7 @@ interface PriceRangeFilterProps {
   onChange: (value: [number, number]) => void
 }
 
-const PriceRangeFilter = ({ minPrice, maxPrice, value, onChange }: PriceRangeFilterProps) => {
+const PriceRangeFilter = ({ value, onChange }: PriceRangeFilterProps) => {
   const [localMinPrice, setLocalMinPrice] = useState<string>(value[0].toString())
   const [localMaxPrice, setLocalMaxPrice] = useState<string>(value[1].toString())
   const [minPriceError, setMinPriceError] = useState<string>('')

--- a/augment-store/client/src/features/products/product-list/components/ShopPage.tsx
+++ b/augment-store/client/src/features/products/product-list/components/ShopPage.tsx
@@ -157,12 +157,12 @@ const ShopPage = () => {
       <PriceRangeFilter
         minPrice={0}
         maxPrice={10000}
-        value={[filters.minPrice || 0, filters.maxPrice || 10000]}
+        value={[filters.minPrice ?? 0, filters.maxPrice ?? 10000]}
         onChange={handlePriceChange}
       />
 
       <RatingFilter
-        value={[filters.minRating || 0, filters.maxRating || 5]}
+        value={[filters.minRating ?? 0, filters.maxRating ?? 5]}
         onChange={handleRatingChange}
       />
     </Box>

--- a/augment-store/client/src/features/products/product-list/components/ShopPage.tsx
+++ b/augment-store/client/src/features/products/product-list/components/ShopPage.tsx
@@ -37,22 +37,10 @@ const ShopPage = () => {
   const [totalCount, setTotalCount] = useState(0)
   const [hasLoadedOnce, setHasLoadedOnce] = useState(false)
 
-  // Calculate min and max prices from products
-  const priceRange = useMemo(() => {
-    if (products.length === 0) {
-      return { min: 0, max: 1000 }
-    }
-    const prices = products.map((p) => p.discountPrice || p.price)
-    return {
-      min: Math.floor(Math.min(...prices)),
-      max: Math.ceil(Math.max(...prices)),
-    }
-  }, [products])
-
   // Filter state
   const [filters, setFilters] = useState<ProductFilters>({
-    minPrice: 0,
-    maxPrice: 1000,
+    minPrice: undefined,
+    maxPrice: undefined,
     minRating: 0,
     maxRating: 5,
   })
@@ -69,6 +57,8 @@ const ShopPage = () => {
       try {
         const response = await productService.getProducts({
           page: apiPage,
+          minPrice: filters.minPrice,
+          maxPrice: filters.maxPrice,
         })
 
         console.log('📦 API Response:', {
@@ -77,6 +67,7 @@ const ShopPage = () => {
           page: response.page,
           limit: response.limit,
           totalPages: response.totalPages,
+          filters: { minPrice: filters.minPrice, maxPrice: filters.maxPrice },
         })
 
         setProducts(response.products)
@@ -94,18 +85,7 @@ const ShopPage = () => {
     }
 
     fetchProducts()
-  }, [apiPage])
-
-  // Update filter price range when products change
-  useEffect(() => {
-    if (products.length > 0 && filters.minPrice === 0 && filters.maxPrice === 1000) {
-      setFilters((prev) => ({
-        ...prev,
-        minPrice: priceRange.min,
-        maxPrice: priceRange.max,
-      }))
-    }
-  }, [priceRange, products.length, filters.minPrice, filters.maxPrice])
+  }, [apiPage, filters.minPrice, filters.maxPrice])
 
   // Calculate client-side pagination (no filtering or sorting for now)
   const totalClientPages = Math.ceil(products.length / PRODUCTS_PER_PAGE)
@@ -155,8 +135,8 @@ const ShopPage = () => {
 
   const handleResetFilters = () => {
     setFilters({
-      minPrice: priceRange.min,
-      maxPrice: priceRange.max,
+      minPrice: undefined,
+      maxPrice: undefined,
       minRating: 0,
       maxRating: 5,
     })
@@ -175,9 +155,9 @@ const ShopPage = () => {
       <Divider sx={{ mb: 3 }} />
 
       <PriceRangeFilter
-        minPrice={priceRange.min}
-        maxPrice={priceRange.max}
-        value={[filters.minPrice || priceRange.min, filters.maxPrice || priceRange.max]}
+        minPrice={0}
+        maxPrice={10000}
+        value={[filters.minPrice || 0, filters.maxPrice || 10000]}
         onChange={handlePriceChange}
       />
 

--- a/augment-store/client/src/services/api/products/productService.ts
+++ b/augment-store/client/src/services/api/products/productService.ts
@@ -21,12 +21,22 @@ export const productService = {
       const page = params?.page || 1
       const backendPageSize = 100 // Fixed in backend REST_FRAMEWORK settings
 
-      // Fetch products from backend with pagination
-      // Note: page_size is fixed at 100 on backend, cannot be overridden
+      // Build query params for backend API
+      const queryParams: Record<string, number | string> = {
+        page,
+      }
+
+      // Add price filters if provided
+      if (params?.minPrice !== undefined && params?.minPrice !== null) {
+        queryParams.price_min = params.minPrice
+      }
+      if (params?.maxPrice !== undefined && params?.maxPrice !== null) {
+        queryParams.price_max = params.maxPrice
+      }
+
+      // Fetch products from backend with pagination and filters
       const response = await apiClient.get<PaginatedProductsAPI>(API_ENDPOINTS.PRODUCTS.LIST, {
-        params: {
-          page,
-        },
+        params: queryParams,
       })
 
       console.log('🔍 Raw API Response:', {
@@ -34,6 +44,7 @@ export const productService = {
         resultsLength: response.results.length,
         next: response.next,
         previous: response.previous,
+        filters: { minPrice: params?.minPrice, maxPrice: params?.maxPrice },
       })
 
       // Transform backend products to frontend format


### PR DESCRIPTION
## Summary
Implemented price filtering functionality with separate min and max price input fields instead of a slider.

## Changes
- **PriceRangeFilter Component**: Replaced slider with two TextField inputs for min and max price
- **Validation**: Added comprehensive validation including:
  - Min price cannot be greater than max price
  - No negative prices allowed
  - Valid numeric values required
  - Error messages displayed below fields
- **Backend Integration**: Integrated with Django backend using `price_min` and `price_max` query parameters
- **User Experience**: 
  - Validation triggers on blur and Enter key press
  - Auto-refetch products when filters change
  - Accessibility improvements with aria-labels
  - Dollar sign prefix for better UX

## Testing
- Navigate to the shop page
- Enter min and max price values in the filter sidebar
- Products automatically filter when you blur the input or press Enter
- Try entering invalid values (e.g., min > max) to see validation in action

## Files Changed
- `augment-store/client/src/features/products/product-list/components/PriceRangeFilter.tsx`
- `augment-store/client/src/features/products/product-list/components/ShopPage.tsx`
- `augment-store/client/src/services/api/products/productService.ts`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author