### PR TITLE
feat: Add rating filter query params (0-10 scale) to products API

### DIFF
--- a/augment-store/client/src/features/products/product-list/components/RatingFilter.tsx
+++ b/augment-store/client/src/features/products/product-list/components/RatingFilter.tsx
@@ -34,16 +34,16 @@ const RatingFilter = ({ value, onChange }: RatingFilterProps) => {
           onChangeCommitted={handleChangeCommitted}
           valueLabelDisplay="auto"
           min={0}
-          max={5}
+          max={10}
           step={0.5}
           disableSwap
           marks={[
             { value: 0, label: '0' },
-            { value: 1, label: '1' },
             { value: 2, label: '2' },
-            { value: 3, label: '3' },
             { value: 4, label: '4' },
-            { value: 5, label: '5' },
+            { value: 6, label: '6' },
+            { value: 8, label: '8' },
+            { value: 10, label: '10' },
           ]}
           sx={{
             '& .MuiSlider-thumb': {
@@ -70,13 +70,13 @@ const RatingFilter = ({ value, onChange }: RatingFilterProps) => {
         />
         <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2 }}>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <Rating value={localValue[0]} readOnly precision={0.5} size="small" />
+            <Rating value={localValue[0] / 2} readOnly precision={0.25} size="small" max={5} />
             <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 500 }}>
               ({localValue[0]})
             </Typography>
           </Box>
           <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <Rating value={localValue[1]} readOnly precision={0.5} size="small" />
+            <Rating value={localValue[1] / 2} readOnly precision={0.25} size="small" max={5} />
             <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 500 }}>
               ({localValue[1]})
             </Typography>

--- a/augment-store/client/src/features/products/product-list/components/ShopPage.tsx
+++ b/augment-store/client/src/features/products/product-list/components/ShopPage.tsx
@@ -54,7 +54,7 @@ const ShopPage = () => {
     minPrice: 0,
     maxPrice: 1000,
     minRating: 0,
-    maxRating: 5,
+    maxRating: 10,
   })
 
   // Sort state
@@ -69,6 +69,8 @@ const ShopPage = () => {
       try {
         const response = await productService.getProducts({
           page: apiPage,
+          minRating: filters.minRating,
+          maxRating: filters.maxRating,
         })
 
         console.log('📦 API Response:', {
@@ -77,6 +79,10 @@ const ShopPage = () => {
           page: response.page,
           limit: response.limit,
           totalPages: response.totalPages,
+          appliedFilters: {
+            minRating: filters.minRating,
+            maxRating: filters.maxRating,
+          },
         })
 
         setProducts(response.products)
@@ -94,7 +100,7 @@ const ShopPage = () => {
     }
 
     fetchProducts()
-  }, [apiPage])
+  }, [apiPage, filters.minRating, filters.maxRating])
 
   // Update filter price range when products change
   useEffect(() => {
@@ -158,7 +164,7 @@ const ShopPage = () => {
       minPrice: priceRange.min,
       maxPrice: priceRange.max,
       minRating: 0,
-      maxRating: 5,
+      maxRating: 10,
     })
   }
 
@@ -182,7 +188,7 @@ const ShopPage = () => {
       />
 
       <RatingFilter
-        value={[filters.minRating || 0, filters.maxRating || 5]}
+        value={[filters.minRating || 0, filters.maxRating || 10]}
         onChange={handleRatingChange}
       />
     </Box>

--- a/augment-store/client/src/features/products/product-list/components/ShopPage.tsx
+++ b/augment-store/client/src/features/products/product-list/components/ShopPage.tsx
@@ -183,12 +183,12 @@ const ShopPage = () => {
       <PriceRangeFilter
         minPrice={priceRange.min}
         maxPrice={priceRange.max}
-        value={[filters.minPrice || priceRange.min, filters.maxPrice || priceRange.max]}
+        value={[filters.minPrice ?? priceRange.min, filters.maxPrice ?? priceRange.max]}
         onChange={handlePriceChange}
       />
 
       <RatingFilter
-        value={[filters.minRating || 0, filters.maxRating || 10]}
+        value={[filters.minRating ?? 0, filters.maxRating ?? 10]}
         onChange={handleRatingChange}
       />
     </Box>

--- a/augment-store/client/src/services/api/products/productService.ts
+++ b/augment-store/client/src/services/api/products/productService.ts
@@ -21,12 +21,22 @@ export const productService = {
       const page = params?.page || 1
       const backendPageSize = 100 // Fixed in backend REST_FRAMEWORK settings
 
-      // Fetch products from backend with pagination
-      // Note: page_size is fixed at 100 on backend, cannot be overridden
+      // Build query params for backend API
+      const queryParams: Record<string, number | string> = {
+        page,
+      }
+
+      // Add rating filters if provided
+      if (params?.minRating !== undefined && params?.minRating !== null) {
+        queryParams.rating_min = params.minRating
+      }
+      if (params?.maxRating !== undefined && params?.maxRating !== null) {
+        queryParams.rating_max = params.maxRating
+      }
+
+      // Fetch products from backend with pagination and filters
       const response = await apiClient.get<PaginatedProductsAPI>(API_ENDPOINTS.PRODUCTS.LIST, {
-        params: {
-          page,
-        },
+        params: queryParams,
       })
 
       console.log('🔍 Raw API Response:', {
@@ -34,6 +44,10 @@ export const productService = {
         resultsLength: response.results.length,
         next: response.next,
         previous: response.previous,
+        filters: {
+          minRating: params?.minRating,
+          maxRating: params?.maxRating,
+        },
       })
 
       // Transform backend products to frontend format


### PR DESCRIPTION
## Summary

This PR implements rating filter query parameters for the products API, allowing users to filter products by rating range on a 0-10 scale.

## Changes

### 1. Product Service (`productService.ts`)
- Added `rating_min` and `rating_max` query parameters to `getProducts()` function
- Query params are only sent when rating filter values are provided
- Added logging for applied rating filters

### 2. Shop Page (`ShopPage.tsx`)
- Updated products fetch to pass `minRating` and `maxRating` from filter state to API
- Added rating filters to useEffect dependency array to refetch when filters change
- Updated initial state and reset function to use max rating of 10

### 3. Rating Filter Component (`RatingFilter.tsx`)
- Scaled rating range from 0-5 to 0-10
- Updated slider marks to show: 0, 2, 4, 6, 8, 10
- Maintained visual star display by dividing values by 2 (10-point scale → 5 stars)
- Shows actual numeric value (0-10) alongside star visualization

## How It Works

1. User adjusts the rating slider (0-10 range)
2. Filter state updates trigger API refetch with `rating_min` and `rating_max` params
3. Backend filters products using Django's RangeFilter
4. Only products within the selected rating range are returned

## Testing

- ✅ Rating filter slider works on 0-10 scale
- ✅ API receives correct `rating_min` and `rating_max` query params
- ✅ Products are filtered correctly by backend
- ✅ Reset filters button resets rating to 0-10
- ✅ Visual star display shows correct representation

## Screenshots

_Rating filter with 0-10 scale and star visualization_

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author