### PR TITLE
fix(products): display actual rating value instead of review count

### DIFF
--- a/augment-store/client/src/features/products/product-detail/components/ProductDetailPage.tsx
+++ b/augment-store/client/src/features/products/product-detail/components/ProductDetailPage.tsx
@@ -273,7 +273,7 @@ const ProductDetailPage = () => {
 
             {/* Rating */}
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
-              <Rating value={ratingNumber} precision={0.1} readOnly />
+              <Rating value={ratingNumber / 2} precision={0.1} readOnly max={5} />
               <Typography variant="body2" color="text.secondary">
                 {ratingNumber.toFixed(1)} (0 reviews)
               </Typography>

--- a/augment-store/client/src/features/products/product-detail/components/ProductDetailPage.tsx
+++ b/augment-store/client/src/features/products/product-detail/components/ProductDetailPage.tsx
@@ -275,7 +275,7 @@ const ProductDetailPage = () => {
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 2 }}>
               <Rating value={ratingNumber / 2} precision={0.1} readOnly max={5} />
               <Typography variant="body2" color="text.secondary">
-                {ratingNumber.toFixed(1)} (0 reviews)
+                ({ratingNumber.toFixed(1)})
               </Typography>
             </Box>
 

--- a/augment-store/client/src/features/products/product-detail/components/ReviewSection.tsx
+++ b/augment-store/client/src/features/products/product-detail/components/ReviewSection.tsx
@@ -1,4 +1,13 @@
-import { Box, Typography, Rating, Avatar, Chip, Divider, LinearProgress, Paper } from '@mui/material'
+import {
+  Box,
+  Typography,
+  Rating,
+  Avatar,
+  Chip,
+  Divider,
+  LinearProgress,
+  Paper,
+} from '@mui/material'
 import { Verified as VerifiedIcon, ThumbUp as ThumbUpIcon } from '@mui/icons-material'
 import type { Review } from '@features/products/types'
 import { formatDistanceToNow } from 'date-fns'
@@ -29,7 +38,14 @@ const ReviewSection = ({ reviews, rating }: ReviewSectionProps) => {
             <Typography variant="h2" sx={{ fontWeight: 700, mb: 1 }}>
               {rating.toFixed(1)}
             </Typography>
-            <Rating value={rating} precision={0.1} readOnly size="large" sx={{ mb: 1 }} />
+            <Rating
+              value={rating / 2}
+              precision={0.1}
+              readOnly
+              size="large"
+              max={5}
+              sx={{ mb: 1 }}
+            />
             <Typography variant="body2" color="text.secondary">
               Based on {reviews.length} review{reviews.length !== 1 ? 's' : ''}
             </Typography>
@@ -67,7 +83,9 @@ const ReviewSection = ({ reviews, rating }: ReviewSectionProps) => {
         <Box sx={{ flex: 1 }}>
           {reviews.length === 0 ? (
             <Paper sx={{ p: 4, textAlign: 'center' }}>
-              <Typography color="text.secondary">No reviews yet. Be the first to review!</Typography>
+              <Typography color="text.secondary">
+                No reviews yet. Be the first to review!
+              </Typography>
             </Paper>
           ) : (
             <Box sx={{ display: 'flex', flexDirection: 'column', gap: 3 }}>
@@ -148,4 +166,3 @@ const ReviewSection = ({ reviews, rating }: ReviewSectionProps) => {
 }
 
 export default ReviewSection
-

--- a/augment-store/client/src/features/products/product-list/components/ProductCard.tsx
+++ b/augment-store/client/src/features/products/product-list/components/ProductCard.tsx
@@ -119,7 +119,7 @@ const ProductCard = ({ product, index = 0 }: ProductCardProps) => {
 
             {/* Rating */}
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
-              <Rating value={product.rating} readOnly precision={0.1} size="small" />
+              <Rating value={product.rating / 2} readOnly precision={0.1} size="small" max={5} />
               <Typography variant="caption" color="text.secondary">
                 ({product.rating.toFixed(1)})
               </Typography>

--- a/augment-store/client/src/features/products/product-list/components/ProductCard.tsx
+++ b/augment-store/client/src/features/products/product-list/components/ProductCard.tsx
@@ -121,7 +121,7 @@ const ProductCard = ({ product, index = 0 }: ProductCardProps) => {
             <Box sx={{ display: 'flex', alignItems: 'center', gap: 1, mb: 1 }}>
               <Rating value={product.rating} readOnly precision={0.1} size="small" />
               <Typography variant="caption" color="text.secondary">
-                ({product.reviewCount})
+                ({product.rating.toFixed(1)})
               </Typography>
             </Box>
 


### PR DESCRIPTION
## Summary
This PR fixes product rating display issues to ensure consistency between the backend's 10-point rating scale and the frontend's 5-star visual representation.

## Problems Fixed

### 1. Rating Display Showing Hardcoded Zero
- ProductCard was displaying `product.reviewCount` which is hardcoded to `0` in the API transformation
- The backend doesn't provide review count yet, so it was always showing `(0)`
- The actual rating value from the API was being correctly parsed but not displayed

### 2. Rating Scale Inconsistency
- Backend uses a 10-point rating scale (0-9.99)
- MUI Rating component defaults to 5-star scale
- This caused visual inconsistency where a rating like `8.7` would appear next to a 5-star component showing all stars filled

## Solutions

### Display Actual Rating Value
- Changed ProductCard to display the actual rating value: `product.rating.toFixed(1)`
- Now shows the real rating from the API (e.g., `(4.5)`, `(8.7)`, etc.)

### Convert 10-Point Scale to 5-Star Display
- Divide rating by 2 when passing to Rating component: `value={rating / 2}`
- Added explicit `max={5}` prop to Rating components
- Maintains visual consistency: 8.7 rating → 4.35 stars displayed
- Numeric text still shows original 10-point scale value

## Changes

**ProductCard.tsx**
- Line 122: Added `value={product.rating / 2}` and `max={5}` to Rating component
- Line 124: Changed `({product.reviewCount})` → `({product.rating.toFixed(1)})`

**ProductDetailPage.tsx**
- Line 276: Added `value={ratingNumber / 2}` and `max={5}` to Rating component

**ReviewSection.tsx**
- Line 42: Added `value={rating / 2}` and `max={5}` to Rating component

## Examples
- Backend rating **8.7** → **4.35 stars** displayed with text **(8.7)**
- Backend rating **5.0** → **2.5 stars** displayed with text **(5.0)**
- Backend rating **9.5** → **4.75 stars** displayed with text **(9.5)**

## Testing
- ✅ Verified rating values display correctly from API
- ✅ Rating shows actual numeric value instead of hardcoded `(0)`
- ✅ Star display matches 10-point scale (divided by 2)
- ✅ Visual consistency between stars and numeric value
- ✅ No TypeScript errors