### PR TITLE
feat(search): limit search results to 12 products using dedicated search endpoint

### DIFF
--- a/augment-store/client/src/components/common/SearchBar.tsx
+++ b/augment-store/client/src/components/common/SearchBar.tsx
@@ -43,7 +43,7 @@ LoadingSpinner.displayName = 'LoadingSpinner'
 const SearchBar = ({
   placeholder = 'Search products...',
   debounceDelay = 500,
-  maxResults = 5,
+  maxResults = 12,
   onResultClick,
 }: SearchBarProps) => {
   const navigate = useNavigate()

--- a/augment-store/client/src/services/api/products/mockProductService.ts
+++ b/augment-store/client/src/services/api/products/mockProductService.ts
@@ -21,16 +21,16 @@ export const mockProductService = {
         product.description.toLowerCase().includes(query.toLowerCase())
     )
 
-    // Apply limit
-    const limit = params?.limit || 5
+    // Apply limit (default 12 to match real service)
+    const limit = params?.limit || 12
     const products = filteredProducts.slice(0, limit)
 
     return {
       products,
       total: filteredProducts.length,
-      page: 1,
+      page: 1, // Search always returns first page only
       limit,
-      totalPages: Math.ceil(filteredProducts.length / limit),
+      totalPages: 1, // Search only shows first page
     }
   },
 

--- a/augment-store/client/src/services/api/products/productService.ts
+++ b/augment-store/client/src/services/api/products/productService.ts
@@ -104,57 +104,26 @@ export const productService = {
     params?: ProductSearchParams
   ): Promise<ProductListResponse> => {
     try {
-      const uiPage = params?.page || 1
       const limit = params?.limit || 12
-      const backendPageSize = 100 // Fixed in backend REST_FRAMEWORK settings
 
-      // Calculate which backend page to fetch based on UI pagination
-      // UI offset: where we want to start in the full result set
-      const uiOffset = (uiPage - 1) * limit
-      // Backend page: which backend page contains our UI offset
-      const backendPage = Math.floor(uiOffset / backendPageSize) + 1
-      // Offset within the backend page results
-      const offsetInBackendPage = uiOffset % backendPageSize
-
-      // Check if we need to fetch the next backend page too
-      const needsNextPage = offsetInBackendPage + limit > backendPageSize
-
-      // Fetch the first backend page
-      const response = await apiClient.get<PaginatedProductsAPI>(API_ENDPOINTS.PRODUCTS.LIST, {
+      // Fetch products from backend using dedicated search endpoint
+      // Backend supports limit parameter to restrict results
+      const response = await apiClient.get<PaginatedProductsAPI>(API_ENDPOINTS.PRODUCTS.SEARCH, {
         params: {
-          page: backendPage,
           search: query,
+          limit: limit,
         },
       })
 
       // Transform backend products to frontend format
-      let allProducts: Product[] = response.results.map(transformProductFromAPI)
-
-      // If we need more items from the next page, fetch it
-      if (needsNextPage && response.next) {
-        const nextResponse = await apiClient.get<PaginatedProductsAPI>(
-          API_ENDPOINTS.PRODUCTS.LIST,
-          {
-            params: {
-              page: backendPage + 1,
-              search: query,
-            },
-          }
-        )
-        const nextProducts = nextResponse.results.map(transformProductFromAPI)
-        allProducts = [...allProducts, ...nextProducts]
-      }
-
-      // Slice the correct range from combined results
-      const limitedProducts = allProducts.slice(offsetInBackendPage, offsetInBackendPage + limit)
+      const products: Product[] = response.results.map(transformProductFromAPI)
 
       return {
-        products: limitedProducts,
+        products,
         total: response.count,
-        page: uiPage,
+        page: 1, // Search always returns first page only
         limit,
-        // Calculate totalPages based on the limit returned in the response
-        totalPages: Math.ceil(response.count / limit),
+        totalPages: 1, // Search only shows first page
       }
     } catch (error) {
       console.error('Failed to search products:', error)


### PR DESCRIPTION
## Summary

Updated the search products functionality to limit results to a maximum of 12 products using the dedicated `/products/search/` endpoint.

## Changes Made

### 1. Product Service (`productService.ts`)
- Changed from `/products` endpoint to dedicated `/products/search/` endpoint
- Simplified search logic to use backend's `limit` parameter
- Removed complex pagination logic (search only returns first page)
- Default limit set to 12 products

### 2. SearchBar Component (`SearchBar.tsx`)
- Updated default `maxResults` from 5 to 12
- Search dropdown now displays up to 12 products

### 3. Mock Product Service (`mockProductService.ts`)
- Updated to match real service behavior
- Changed default limit from 5 to 12
- Returns only first page to match real service

## Behavior

- Users typing in the search bar will see up to 12 matching products
- Search results are limited to the first page only
- For more comprehensive product browsing, users can visit the full `/products` page
- The implementation leverages the backend's dedicated search endpoint with built-in limit support

## Testing

- Tested with the dedicated `/products/search/` endpoint
- Verified limit parameter is correctly passed to the API
- Confirmed search results are capped at 12 products

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author