### PR TITLE
fix: prevent invalid characters in price filter inputs

### DIFF
--- a/augment-store/client/src/features/products/product-list/components/PriceRangeFilter.tsx
+++ b/augment-store/client/src/features/products/product-list/components/PriceRangeFilter.tsx
@@ -69,8 +69,8 @@ const PriceRangeFilter = ({ value, onChange }: PriceRangeFilterProps) => {
   }
 
   const sanitizeNumericInput = (value: string): string => {
-    // Remove invalid characters: e, E, +, -
-    // Allow only digits and decimal point
+    // Remove characters that are invalid for price inputs: e, E, +, -
+    // (scientific notation and sign characters)
     return value.replace(/[eE+-]/g, '')
   }
 

--- a/augment-store/client/src/features/products/product-list/components/PriceRangeFilter.tsx
+++ b/augment-store/client/src/features/products/product-list/components/PriceRangeFilter.tsx
@@ -92,15 +92,15 @@ const PriceRangeFilter = ({ value, onChange }: PriceRangeFilterProps) => {
       event.preventDefault()
 
       const input = event.currentTarget
-      const start = input.selectionStart ?? 0
-      const end = input.selectionEnd ?? 0
       const currentValue = input.value
 
       // Sanitize the pasted text
       const sanitized = sanitizeNumericInput(pastedText)
 
-      // Insert sanitized text at cursor position, replacing any selection
-      const newValue = currentValue.substring(0, start) + sanitized + currentValue.substring(end)
+      // Note: We cannot use selectionStart/selectionEnd or setSelectionRange on type="number" inputs
+      // as they are not supported in most browsers and will throw errors.
+      // Instead, we append the sanitized text to the current value.
+      const newValue = currentValue + sanitized
 
       // Determine which field and update state
       if (input.name === 'minPrice') {
@@ -108,11 +108,6 @@ const PriceRangeFilter = ({ value, onChange }: PriceRangeFilterProps) => {
       } else if (input.name === 'maxPrice') {
         setLocalMaxPrice(newValue)
       }
-
-      // Set cursor position after the pasted text
-      setTimeout(() => {
-        input.setSelectionRange(start + sanitized.length, start + sanitized.length)
-      }, 0)
     }
   }
 

--- a/augment-store/client/src/features/products/product-list/components/PriceRangeFilter.tsx
+++ b/augment-store/client/src/features/products/product-list/components/PriceRangeFilter.tsx
@@ -68,14 +68,40 @@ const PriceRangeFilter = ({ value, onChange }: PriceRangeFilterProps) => {
     }
   }
 
+  const sanitizeNumericInput = (value: string): string => {
+    // Remove invalid characters: e, E, +, -
+    // Allow only digits and decimal point
+    return value.replace(/[eE+-]/g, '')
+  }
+
   const handleMinPriceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = event.target.value
+    const newValue = sanitizeNumericInput(event.target.value)
     setLocalMinPrice(newValue)
   }
 
   const handleMaxPriceChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    const newValue = event.target.value
+    const newValue = sanitizeNumericInput(event.target.value)
     setLocalMaxPrice(newValue)
+  }
+
+  const handlePaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
+    // Get pasted text
+    const pastedText = event.clipboardData.getData('text')
+
+    // Check if pasted text contains invalid characters
+    if (/[eE+-]/.test(pastedText)) {
+      event.preventDefault()
+
+      // Sanitize and set the value manually
+      const sanitized = sanitizeNumericInput(pastedText)
+      const target = event.currentTarget
+
+      if (target.name === 'minPrice') {
+        setLocalMinPrice(sanitized)
+      } else if (target.name === 'maxPrice') {
+        setLocalMaxPrice(sanitized)
+      }
+    }
   }
 
   const handleMinPriceBlur = () => {
@@ -108,10 +134,12 @@ const PriceRangeFilter = ({ value, onChange }: PriceRangeFilterProps) => {
           <TextField
             label="Min Price"
             type="number"
+            name="minPrice"
             value={localMinPrice}
             onChange={handleMinPriceChange}
             onBlur={handleMinPriceBlur}
             onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
             error={!!minPriceError}
             helperText={minPriceError}
             size="small"
@@ -125,10 +153,12 @@ const PriceRangeFilter = ({ value, onChange }: PriceRangeFilterProps) => {
           <TextField
             label="Max Price"
             type="number"
+            name="maxPrice"
             value={localMaxPrice}
             onChange={handleMaxPriceChange}
             onBlur={handleMaxPriceBlur}
             onKeyDown={handleKeyDown}
+            onPaste={handlePaste}
             error={!!maxPriceError}
             helperText={maxPriceError}
             size="small"

--- a/augment-store/client/src/features/products/product-list/components/PriceRangeFilter.tsx
+++ b/augment-store/client/src/features/products/product-list/components/PriceRangeFilter.tsx
@@ -87,6 +87,12 @@ const PriceRangeFilter = ({ value, onChange }: PriceRangeFilterProps) => {
   }
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    // Prevent 'e', 'E', '+', '-' from being entered in number input
+    if (event.key === 'e' || event.key === 'E' || event.key === '+' || event.key === '-') {
+      event.preventDefault()
+      return
+    }
+
     if (event.key === 'Enter') {
       validateAndUpdate(localMinPrice, localMaxPrice)
     }

--- a/augment-store/client/src/features/products/product-list/components/PriceRangeFilter.tsx
+++ b/augment-store/client/src/features/products/product-list/components/PriceRangeFilter.tsx
@@ -85,22 +85,34 @@ const PriceRangeFilter = ({ value, onChange }: PriceRangeFilterProps) => {
   }
 
   const handlePaste = (event: React.ClipboardEvent<HTMLInputElement>) => {
-    // Get pasted text
     const pastedText = event.clipboardData.getData('text')
 
     // Check if pasted text contains invalid characters
     if (/[eE+-]/.test(pastedText)) {
       event.preventDefault()
 
-      // Sanitize and set the value manually
-      const sanitized = sanitizeNumericInput(pastedText)
-      const target = event.currentTarget
+      const input = event.currentTarget
+      const start = input.selectionStart ?? 0
+      const end = input.selectionEnd ?? 0
+      const currentValue = input.value
 
-      if (target.name === 'minPrice') {
-        setLocalMinPrice(sanitized)
-      } else if (target.name === 'maxPrice') {
-        setLocalMaxPrice(sanitized)
+      // Sanitize the pasted text
+      const sanitized = sanitizeNumericInput(pastedText)
+
+      // Insert sanitized text at cursor position, replacing any selection
+      const newValue = currentValue.substring(0, start) + sanitized + currentValue.substring(end)
+
+      // Determine which field and update state
+      if (input.name === 'minPrice') {
+        setLocalMinPrice(newValue)
+      } else if (input.name === 'maxPrice') {
+        setLocalMaxPrice(newValue)
       }
+
+      // Set cursor position after the pasted text
+      setTimeout(() => {
+        input.setSelectionRange(start + sanitized.length, start + sanitized.length)
+      }, 0)
     }
   }
 


### PR DESCRIPTION
## Description
Fixed an issue where users could type the letter 'e' (and other invalid characters) in the price filter input fields.

## Changes
- Updated `PriceRangeFilter.tsx` to prevent invalid characters (e, E, +, -) from being entered in price input fields
- Added keyboard event prevention in the `handleKeyDown` handler

## Why
HTML number inputs allow 'e' for scientific notation (e.g., 1e5), and '+'/'-' for positive/negative numbers. These characters should not be allowed in price inputs as they can confuse users and lead to invalid price values.

## Testing
- Users can now only enter valid numeric characters (0-9 and decimal point) in price filter inputs
- Enter key still triggers validation as expected

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author