### PR TITLE
feat(checkout): pre-fill contact info with user profile data and reduce input size

### DIFF
--- a/augment-store/client/src/features/checkout/components/CheckoutPage.tsx
+++ b/augment-store/client/src/features/checkout/components/CheckoutPage.tsx
@@ -142,6 +142,41 @@ const CheckoutPage = () => {
     Partial<Record<keyof ContactInfo | keyof ShippingAddress, boolean>>
   >({})
 
+  // Fetch user profile and pre-fill contact info (only for empty/untouched fields)
+  useEffect(() => {
+    let isMounted = true
+
+    const fetchUserProfile = async () => {
+      if (!isAuthenticated) return
+
+      try {
+        const profile = await userService.getProfile()
+
+        // Only update state if component is still mounted
+        if (!isMounted) return
+
+        // Only update fields that are still empty and haven't been touched by the user
+        setContactInfo((prev) => ({
+          email: prev.email === '' && !touched.email ? profile.email || '' : prev.email,
+          phone: prev.phone === '' && !touched.phone ? profile.mobile || '' : prev.phone,
+          firstName:
+            prev.firstName === '' && !touched.firstName ? profile.first_name || '' : prev.firstName,
+          lastName:
+            prev.lastName === '' && !touched.lastName ? profile.last_name || '' : prev.lastName,
+        }))
+      } catch (error) {
+        console.error('Failed to fetch user profile:', error)
+        // Silently fail - user can still fill in the form manually
+      }
+    }
+
+    fetchUserProfile()
+
+    return () => {
+      isMounted = false
+    }
+  }, [isAuthenticated, touched.email, touched.phone, touched.firstName, touched.lastName])
+
   const createFieldValidator = useCallback(
     <T extends z.ZodTypeAny>(schema: z.ZodObject<Record<string, T>>) =>
       (field: string, value: string) => {

--- a/augment-store/client/src/features/checkout/components/CheckoutPage.tsx
+++ b/augment-store/client/src/features/checkout/components/CheckoutPage.tsx
@@ -107,10 +107,12 @@ const CheckoutPage = () => {
 
         // Only update fields that are still empty and haven't been touched by the user
         setContactInfo((prev) => ({
-          email: prev.email === '' ? profile.email || '' : prev.email,
-          phone: prev.phone === '' ? profile.mobile || '' : prev.phone,
-          firstName: prev.firstName === '' ? profile.first_name || '' : prev.firstName,
-          lastName: prev.lastName === '' ? profile.last_name || '' : prev.lastName,
+          email: prev.email === '' && !touched.email ? profile.email || '' : prev.email,
+          phone: prev.phone === '' && !touched.phone ? profile.mobile || '' : prev.phone,
+          firstName:
+            prev.firstName === '' && !touched.firstName ? profile.first_name || '' : prev.firstName,
+          lastName:
+            prev.lastName === '' && !touched.lastName ? profile.last_name || '' : prev.lastName,
         }))
       } catch (error) {
         console.error('Failed to fetch user profile:', error)
@@ -123,7 +125,7 @@ const CheckoutPage = () => {
     return () => {
       isMounted = false
     }
-  }, [isAuthenticated])
+  }, [isAuthenticated, touched.email, touched.phone, touched.firstName, touched.lastName])
 
   const validateField = useCallback((field: keyof ContactInfo, value: string) => {
     try {

--- a/augment-store/client/src/features/checkout/components/CheckoutPage.tsx
+++ b/augment-store/client/src/features/checkout/components/CheckoutPage.tsx
@@ -92,19 +92,21 @@ const CheckoutPage = () => {
   const [errors, setErrors] = useState<Partial<Record<keyof ContactInfo, string>>>({})
   const [touched, setTouched] = useState<Partial<Record<keyof ContactInfo, boolean>>>({})
 
-  // Fetch user profile and pre-fill contact info
+  // Fetch user profile and pre-fill contact info (only for empty/untouched fields)
   useEffect(() => {
     const fetchUserProfile = async () => {
       if (!isAuthenticated) return
 
       try {
         const profile = await userService.getProfile()
-        setContactInfo({
-          email: profile.email || '',
-          phone: profile.mobile || '',
-          firstName: profile.first_name || '',
-          lastName: profile.last_name || '',
-        })
+
+        // Only update fields that are still empty and haven't been touched by the user
+        setContactInfo((prev) => ({
+          email: prev.email === '' ? profile.email || '' : prev.email,
+          phone: prev.phone === '' ? profile.mobile || '' : prev.phone,
+          firstName: prev.firstName === '' ? profile.first_name || '' : prev.firstName,
+          lastName: prev.lastName === '' ? profile.last_name || '' : prev.lastName,
+        }))
       } catch (error) {
         console.error('Failed to fetch user profile:', error)
         // Silently fail - user can still fill in the form manually

--- a/augment-store/client/src/features/checkout/components/CheckoutPage.tsx
+++ b/augment-store/client/src/features/checkout/components/CheckoutPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { useState, useCallback, useEffect } from 'react'
 import {
   Accordion,
   AccordionDetails,
@@ -20,6 +20,8 @@ import {
 } from '@mui/icons-material'
 import { z } from 'zod'
 import OrderSummary from '@/features/checkout/components/OrderSummary'
+import { userService } from '@services/api/user/userService'
+import { useAuthStore } from '@store/authStore'
 
 const contactInfoSchema = z.object({
   email: z.string().min(1, 'Email is required').email('Invalid email address'),
@@ -34,7 +36,10 @@ const contactInfoSchema = z.object({
         // Check if it contains only digits after removing the optional +
         return /^\d+$/.test(digitsOnly)
       },
-      { message: 'Phone number can only contain digits, spaces, hyphens, parentheses, and an optional + prefix' }
+      {
+        message:
+          'Phone number can only contain digits, spaces, hyphens, parentheses, and an optional + prefix',
+      }
     )
     .refine(
       (val) => {
@@ -59,17 +64,24 @@ const contactInfoSchema = z.object({
     .string()
     .min(1, 'First name is required')
     .max(50, 'First name is too long')
-    .regex(/^[a-zA-Z\s\-']+$/, 'First name can only contain letters, spaces, hyphens, and apostrophes'),
+    .regex(
+      /^[a-zA-Z\s\-']+$/,
+      'First name can only contain letters, spaces, hyphens, and apostrophes'
+    ),
   lastName: z
     .string()
     .min(1, 'Last name is required')
     .max(50, 'Last name is too long')
-    .regex(/^[a-zA-Z\s\-']+$/, 'Last name can only contain letters, spaces, hyphens, and apostrophes'),
+    .regex(
+      /^[a-zA-Z\s\-']+$/,
+      'Last name can only contain letters, spaces, hyphens, and apostrophes'
+    ),
 })
 
 type ContactInfo = z.infer<typeof contactInfoSchema>
 
 const CheckoutPage = () => {
+  const { isAuthenticated } = useAuthStore()
   const [contactInfo, setContactInfo] = useState<ContactInfo>({
     email: '',
     phone: '',
@@ -79,6 +91,28 @@ const CheckoutPage = () => {
 
   const [errors, setErrors] = useState<Partial<Record<keyof ContactInfo, string>>>({})
   const [touched, setTouched] = useState<Partial<Record<keyof ContactInfo, boolean>>>({})
+
+  // Fetch user profile and pre-fill contact info
+  useEffect(() => {
+    const fetchUserProfile = async () => {
+      if (!isAuthenticated) return
+
+      try {
+        const profile = await userService.getProfile()
+        setContactInfo({
+          email: profile.email || '',
+          phone: profile.mobile || '',
+          firstName: profile.first_name || '',
+          lastName: profile.last_name || '',
+        })
+      } catch (error) {
+        console.error('Failed to fetch user profile:', error)
+        // Silently fail - user can still fill in the form manually
+      }
+    }
+
+    fetchUserProfile()
+  }, [isAuthenticated])
 
   const validateField = useCallback((field: keyof ContactInfo, value: string) => {
     try {
@@ -192,6 +226,7 @@ const CheckoutPage = () => {
                 <Grid item xs={12} sm={6}>
                   <TextField
                     fullWidth
+                    size="small"
                     label="First Name"
                     value={contactInfo.firstName}
                     onChange={handleContactChange('firstName')}
@@ -206,6 +241,7 @@ const CheckoutPage = () => {
                 <Grid item xs={12} sm={6}>
                   <TextField
                     fullWidth
+                    size="small"
                     label="Last Name"
                     value={contactInfo.lastName}
                     onChange={handleContactChange('lastName')}
@@ -220,6 +256,7 @@ const CheckoutPage = () => {
                 <Grid item xs={12}>
                   <TextField
                     fullWidth
+                    size="small"
                     label="Email Address"
                     type="email"
                     value={contactInfo.email}
@@ -227,7 +264,9 @@ const CheckoutPage = () => {
                     onBlur={handleBlur('email')}
                     error={touched.email && !!errors.email}
                     helperText={
-                      touched.email && errors.email ? errors.email : "We'll send your order confirmation here"
+                      touched.email && errors.email
+                        ? errors.email
+                        : "We'll send your order confirmation here"
                     }
                     required
                     variant="outlined"
@@ -237,6 +276,7 @@ const CheckoutPage = () => {
                 <Grid item xs={12}>
                   <TextField
                     fullWidth
+                    size="small"
                     label="Phone Number"
                     type="tel"
                     value={contactInfo.phone}

--- a/augment-store/client/src/features/checkout/components/CheckoutPage.tsx
+++ b/augment-store/client/src/features/checkout/components/CheckoutPage.tsx
@@ -94,11 +94,16 @@ const CheckoutPage = () => {
 
   // Fetch user profile and pre-fill contact info (only for empty/untouched fields)
   useEffect(() => {
+    let isMounted = true
+
     const fetchUserProfile = async () => {
       if (!isAuthenticated) return
 
       try {
         const profile = await userService.getProfile()
+
+        // Only update state if component is still mounted
+        if (!isMounted) return
 
         // Only update fields that are still empty and haven't been touched by the user
         setContactInfo((prev) => ({
@@ -114,6 +119,10 @@ const CheckoutPage = () => {
     }
 
     fetchUserProfile()
+
+    return () => {
+      isMounted = false
+    }
   }, [isAuthenticated])
 
   const validateField = useCallback((field: keyof ContactInfo, value: string) => {


### PR DESCRIPTION
## Summary

This PR enhances the checkout page by automatically pre-filling contact information fields with the logged-in user's profile data and reducing the input field sizes for a better UI.

## Changes Made

### 1. Auto-fill Contact Information
- Added `useEffect` hook to fetch user profile data on component mount
- Pre-fills contact form fields with user's profile data:
  - **Email** from `profile.email`
  - **Phone** from `profile.mobile`
  - **First Name** from `profile.first_name`
  - **Last Name** from `profile.last_name`
- Only fetches profile when user is authenticated
- Gracefully handles errors (allows manual form entry if fetch fails)

### 2. Reduced Input Field Size
- Added `size="small"` prop to all TextField components
- Reduces input height from ~56px to ~40px for a more compact, cleaner appearance
- Applied to all 4 contact information fields

## Technical Details
- Uses existing `userService.getProfile()` API method
- Imports `useAuthStore` to check authentication state
- Maintains all existing validation and error handling logic
- No breaking changes to existing functionality

## Testing
- ✅ Logged-in users see pre-filled contact information
- ✅ Non-authenticated users can still fill the form manually
- ✅ Users can edit pre-filled values
- ✅ All validation rules still work correctly
- ✅ Error handling works as expected

## Screenshots
_Contact form fields are now smaller and pre-filled with user data_

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author