### PR TITLE
refactor(ui): remove star displays below rating range slider

### DIFF
--- a/augment-store/client/src/features/products/product-list/components/RatingFilter.tsx
+++ b/augment-store/client/src/features/products/product-list/components/RatingFilter.tsx
@@ -1,4 +1,4 @@
-import { Box, Rating, Slider, Typography } from '@mui/material'
+import { Box, Slider, Typography } from '@mui/material'
 import { SyntheticEvent, useEffect, useState } from 'react'
 
 interface RatingFilterProps {
@@ -79,20 +79,6 @@ const RatingFilter = ({ value, onChange }: RatingFilterProps) => {
             },
           }}
         />
-        <Box sx={{ display: 'flex', justifyContent: 'space-between', mt: 2 }}>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <Rating value={localValue[0] / 2} readOnly precision={0.25} size="small" max={5} />
-            <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 500 }}>
-              ({localValue[0]})
-            </Typography>
-          </Box>
-          <Box sx={{ display: 'flex', alignItems: 'center', gap: 0.5 }}>
-            <Rating value={localValue[1] / 2} readOnly precision={0.25} size="small" max={5} />
-            <Typography variant="caption" color="text.secondary" sx={{ fontWeight: 500 }}>
-              ({localValue[1]})
-            </Typography>
-          </Box>
-        </Box>
       </Box>
     </Box>
   )


### PR DESCRIPTION
## Changes

Removed the two star displays that appeared below the Rating Range slider in the product filters:
- Removed the minimum rating star display (showing 0 with empty stars)
- Removed the maximum rating star display (showing 10 with full stars)
- Cleaned up unused `Rating` import from MUI

## Rationale

The slider already shows numeric labels (0, 2, 4, 6, 8, 10) and displays current values in tooltips when interacting with it. The additional star displays were redundant and cluttered the UI.

## Files Changed

- `augment-store/client/src/features/products/product-list/components/RatingFilter.tsx`
  - Removed star display components (lines 82-95)
  - Removed unused `Rating` import

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author