### PR TITLE
feat(products): replace sidebar drawer with centered modal for mobile filters

### DIFF
--- a/augment-store/client/src/features/products/product-list/components/ShopPage.tsx
+++ b/augment-store/client/src/features/products/product-list/components/ShopPage.tsx
@@ -1,13 +1,15 @@
 import type { Product, ProductFilters, SortBy } from '@features/products/types'
-import { FilterList as FilterListIcon } from '@mui/icons-material'
+import { Close as CloseIcon, FilterList as FilterListIcon } from '@mui/icons-material'
 import {
   Box,
   Button,
   CircularProgress,
   Container,
+  Dialog,
+  DialogContent,
   Divider,
-  Drawer,
   Grid,
+  IconButton,
   Pagination,
   Paper,
   Typography,
@@ -155,15 +157,27 @@ const ShopPage = () => {
     })
   }
 
-  const FiltersContent = () => (
+  const FiltersContent = ({ showCloseButton = false }: { showCloseButton?: boolean }) => (
     <Box>
       <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
         <Typography variant="h6" sx={{ fontWeight: 600 }}>
           Filters
         </Typography>
-        <Button size="small" onClick={handleResetFilters}>
-          Reset
-        </Button>
+        <Box sx={{ display: 'flex', gap: 1, alignItems: 'center' }}>
+          <Button size="small" onClick={handleResetFilters}>
+            Reset
+          </Button>
+          {showCloseButton && (
+            <IconButton
+              onClick={() => setMobileFiltersOpen(false)}
+              size="small"
+              aria-label="Close filters"
+              sx={{ ml: 1 }}
+            >
+              <CloseIcon />
+            </IconButton>
+          )}
+        </Box>
       </Box>
       <Divider sx={{ mb: 3 }} />
 
@@ -289,12 +303,23 @@ const ShopPage = () => {
         </Grid>
       </Grid>
 
-      {/* Mobile Filters Drawer */}
-      <Drawer anchor="left" open={mobileFiltersOpen} onClose={() => setMobileFiltersOpen(false)}>
-        <Box sx={{ width: 300, p: 3 }}>
-          <FiltersContent />
-        </Box>
-      </Drawer>
+      {/* Mobile Filters Modal */}
+      <Dialog
+        open={mobileFiltersOpen}
+        onClose={() => setMobileFiltersOpen(false)}
+        maxWidth="sm"
+        fullWidth
+        PaperProps={{
+          sx: {
+            m: 2,
+            maxHeight: 'calc(100vh - 64px)',
+          },
+        }}
+      >
+        <DialogContent sx={{ p: 3 }}>
+          <FiltersContent showCloseButton={true} />
+        </DialogContent>
+      </Dialog>
     </Container>
   )
 }


### PR DESCRIPTION
## Summary

Replaced the full-height sidebar filtering drawer with a centered modal for mobile view to improve UX and space utilization.

## Changes

- ✅ Replaced `Drawer` component with `Dialog` (centered modal) for mobile filters
- ✅ Added close button (X icon) to the filter modal header
- ✅ Improved space utilization - modal only takes needed space instead of full height
- ✅ Added proper accessibility with `aria-label` for close button
- ✅ Modal can be closed via:
  - Close button (X icon)
  - Clicking outside the modal
  - Pressing ESC key

## Technical Details

### Updated Components
- `ShopPage.tsx`: 
  - Updated imports to use `Dialog`, `DialogContent`, `IconButton`, and `CloseIcon`
  - Enhanced `FiltersContent` component with optional `showCloseButton` prop
  - Replaced full-height `Drawer` with centered `Dialog` modal
  - Added responsive sizing with `maxWidth="sm"` and proper margins

### Before
- Full-height sidebar drawer on mobile
- More than half of the sidebar was empty space
- No dedicated close button

### After
- Centered modal that only takes up necessary space
- Close button in the header for better UX
- Better visual hierarchy and space utilization

## Testing

- [ ] Verify modal appears centered on mobile devices
- [ ] Verify close button works correctly
- [ ] Verify clicking outside modal closes it
- [ ] Verify ESC key closes the modal
- [ ] Verify filters still work as expected
- [ ] Verify Reset button still works

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author