### PR TITLE
feat(products): add brand filtering support

### DIFF
--- a/augment-store/client/src/config/api.ts
+++ b/augment-store/client/src/config/api.ts
@@ -24,6 +24,7 @@ export const API_ENDPOINTS = {
     DETAIL: (id: string) => `/products/${id}`,
     SEARCH: '/products/search',
     CATEGORIES: '/products/categories',
+    BRANDS: '/products/brands',
     FEATURED: '/products/featured',
   },
 

--- a/augment-store/client/src/features/products/product-list/components/ShopPage.tsx
+++ b/augment-store/client/src/features/products/product-list/components/ShopPage.tsx
@@ -32,8 +32,9 @@ const ShopPage = () => {
   const [mobileFiltersOpen, setMobileFiltersOpen] = useState(false)
   const [searchParams, setSearchParams] = useSearchParams()
 
-  // Read category slug from URL query parameter
+  // Read category slug and brand name from URL query parameters
   const categorySlugFromUrl = searchParams.get('category')
+  const brandNameFromUrl = searchParams.get('brand')
 
   // API state
   const [products, setProducts] = useState<Product[]>([])
@@ -47,6 +48,7 @@ const ShopPage = () => {
   // Filter state - no filters applied by default
   const [filters, setFilters] = useState<ProductFilters>({
     categorySlug: categorySlugFromUrl ?? undefined,
+    brandName: brandNameFromUrl ?? undefined,
     minPrice: undefined,
     maxPrice: undefined,
     minRating: undefined,
@@ -56,20 +58,22 @@ const ShopPage = () => {
   // Sort state
   const [sortBy, setSortBy] = useState<SortBy>('newest')
 
-  // Update filters when URL category parameter changes
+  // Update filters when URL category or brand parameters change
   useEffect(() => {
     setFilters((prev) => {
       const newCategorySlug = categorySlugFromUrl ?? undefined
-      // Only update if the value actually changed
-      if (prev.categorySlug !== newCategorySlug) {
+      const newBrandName = brandNameFromUrl ?? undefined
+      // Only update if the values actually changed
+      if (prev.categorySlug !== newCategorySlug || prev.brandName !== newBrandName) {
         return {
           ...prev,
           categorySlug: newCategorySlug,
+          brandName: newBrandName,
         }
       }
       return prev
     })
-  }, [categorySlugFromUrl])
+  }, [categorySlugFromUrl, brandNameFromUrl])
 
   // Fetch products from API (backend returns 100 items per page)
   useEffect(() => {
@@ -81,6 +85,7 @@ const ShopPage = () => {
         const response = await productService.getProducts({
           page: apiPage,
           categorySlug: filters.categorySlug,
+          brandName: filters.brandName,
           minRating: filters.minRating,
           maxRating: filters.maxRating,
           minPrice: filters.minPrice,
@@ -95,6 +100,7 @@ const ShopPage = () => {
           totalPages: response.totalPages,
           filters: {
             categorySlug: filters.categorySlug,
+            brandName: filters.brandName,
             minPrice: filters.minPrice,
             maxPrice: filters.maxPrice,
             minRating: filters.minRating,
@@ -120,6 +126,7 @@ const ShopPage = () => {
   }, [
     apiPage,
     filters.categorySlug,
+    filters.brandName,
     filters.minPrice,
     filters.maxPrice,
     filters.minRating,
@@ -181,14 +188,16 @@ const ShopPage = () => {
   const handleResetFilters = () => {
     setFilters({
       categorySlug: undefined,
+      brandName: undefined,
       minPrice: undefined,
       maxPrice: undefined,
       minRating: undefined,
       maxRating: undefined,
     })
-    // Remove category query parameter from URL
+    // Remove category and brand query parameters from URL
     const newSearchParams = new URLSearchParams(searchParams)
     newSearchParams.delete('category')
+    newSearchParams.delete('brand')
     setSearchParams(newSearchParams)
   }
 

--- a/augment-store/client/src/features/products/types/api.ts
+++ b/augment-store/client/src/features/products/types/api.ts
@@ -121,3 +121,15 @@ export function transformCategoryFromAPI(apiCategory: ProductCategoryAPI) {
     parent: apiCategory.parent || undefined,
   }
 }
+
+/**
+ * Transform backend brand to frontend brand format
+ */
+export function transformBrandFromAPI(apiBrand: ProductBrandAPI) {
+  return {
+    id: apiBrand.id,
+    name: apiBrand.name,
+    description: apiBrand.description,
+    image: apiBrand.image?.file || undefined,
+  }
+}

--- a/augment-store/client/src/features/products/types/index.ts
+++ b/augment-store/client/src/features/products/types/index.ts
@@ -49,9 +49,24 @@ export interface CategoryAPIResponse {
   results: import('./api').ProductCategoryAPI[]
 }
 
+export interface Brand {
+  id: string
+  name: string
+  description?: string
+  image?: string
+}
+
+export interface BrandAPIResponse {
+  count: number
+  next: string | null
+  previous: string | null
+  results: import('./api').ProductBrandAPI[]
+}
+
 export interface ProductFilters {
   // TEMPORARY: Using categorySlug generated from name until backend exposes slug field
   categorySlug?: string
+  brandName?: string
   minPrice?: number
   maxPrice?: number
   minRating?: number
@@ -72,6 +87,7 @@ export interface ProductSearchParams {
   search?: string
   // TEMPORARY: Using categorySlug generated from name until backend exposes slug field
   categorySlug?: string
+  brandName?: string
   minPrice?: number
   maxPrice?: number
   minRating?: number

--- a/augment-store/client/src/services/api/products/productService.ts
+++ b/augment-store/client/src/services/api/products/productService.ts
@@ -6,9 +6,15 @@ import type {
   ProductSearchParams,
   Category,
   CategoryAPIResponse,
+  Brand,
+  BrandAPIResponse,
 } from '@features/products/types'
 import type { PaginatedProductsAPI, ProductDetailAPI } from '@features/products/types/api'
-import { transformProductFromAPI, transformCategoryFromAPI } from '@features/products/types/api'
+import {
+  transformProductFromAPI,
+  transformCategoryFromAPI,
+  transformBrandFromAPI,
+} from '@features/products/types/api'
 
 export const productService = {
   /**
@@ -30,6 +36,11 @@ export const productService = {
       // TEMPORARY: Using slug generated from category name until backend exposes slug field
       if (params?.categorySlug) {
         queryParams.category = params.categorySlug
+      }
+
+      // Add brand filter if provided (using brand name)
+      if (params?.brandName) {
+        queryParams.brand = params.brandName
       }
 
       // Add rating filters if provided
@@ -60,6 +71,7 @@ export const productService = {
         previous: response.previous,
         filters: {
           categorySlug: params?.categorySlug,
+          brandName: params?.brandName,
           minRating: params?.minRating,
           maxRating: params?.maxRating,
           minPrice: params?.minPrice,
@@ -160,6 +172,26 @@ export const productService = {
       return allCategories
     } catch (error) {
       console.error('Failed to fetch categories:', error)
+      return []
+    }
+  },
+
+  getBrands: async (): Promise<Brand[]> => {
+    try {
+      let allBrands: Brand[] = []
+      let nextUrl: string | null = API_ENDPOINTS.PRODUCTS.BRANDS
+
+      while (nextUrl) {
+        const response: BrandAPIResponse = await apiClient.get<BrandAPIResponse>(nextUrl)
+        // Transform backend brands to frontend format
+        const transformedBrands = (response.results || []).map(transformBrandFromAPI)
+        allBrands = [...allBrands, ...transformedBrands]
+        nextUrl = response.next
+      }
+
+      return allBrands
+    } catch (error) {
+      console.error('Failed to fetch brands:', error)
       return []
     }
   },

--- a/augment-store/server/products/filters.py
+++ b/augment-store/server/products/filters.py
@@ -7,7 +7,7 @@ class ProductFilter(filters.FilterSet):
     rating = filters.RangeFilter()
     price = filters.RangeFilter()
     category = filters.CharFilter(field_name="category__slug")
-    brand = filters.CharFilter(field_name="brand__name")
+    brand = filters.CharFilter(field_name="brand__name", lookup_expr='iexact')
     quantity = filters.RangeFilter()
     limit = filters.NumberFilter(field_name="limit", method="filter_limit", max_value=100, min_value=1)
 


### PR DESCRIPTION
## Summary

This PR adds brand filtering functionality to the products page, allowing users to filter products by brand name via URL parameter (e.g., `?brand=p1810`).

## Changes

### Frontend
- ✅ Added `brandName` field to `ProductFilters` and `ProductSearchParams` TypeScript interfaces
- ✅ Updated `productService.getProducts()` to accept and send `brand` parameter to backend API
- ✅ Added `getBrands()` method to fetch all brands from backend
- ✅ Added `Brand` interface and `BrandAPIResponse` type for type safety
- ✅ Added `transformBrandFromAPI()` function for data transformation
- ✅ Updated `ShopPage` component to:
  - Read `brand` query parameter from URL
  - Include `brandName` in filters state
  - Pass `brandName` to API calls
  - Clear brand filter when resetting filters
- ✅ Added `BRANDS` endpoint to API configuration

### Backend
- ✅ Made brand filter case-insensitive by adding `lookup_expr='iexact'` to the `ProductFilter` class
  - Now `?brand=p1810`, `?brand=P1810`, and `?brand=P1810` all work correctly

## How to Test

1. Navigate to `http://localhost:3000/products?brand=p1810`
2. Verify that only products from the "P1810" brand are displayed
3. Try different brand names (case-insensitive): `?brand=P2910`, `?brand=p2980`, etc.
4. Verify that the brand filter can be combined with other filters (category, price, rating)
5. Verify that clicking "Reset Filters" clears the brand filter from the URL

## Technical Notes

- The backend expects the **brand name** (not ID or slug) as the filter parameter
- The `ProductBrand` model does not have a `slug` field, only a `name` field
- The filter is now case-insensitive for better UX
- The `getBrands()` method is ready for future use (e.g., brands page similar to categories page)

## Related Issues

Fixes filtering products based on brand slug/name from URL parameters.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author