### PR TITLE
feat(theme): add createAppTheme function for dynamic theme mode

### DIFF
--- a/augment-store/client/src/config/theme.ts
+++ b/augment-store/client/src/config/theme.ts
@@ -1,96 +1,108 @@
-import { createTheme } from '@mui/material/styles'
+import { createTheme, type Theme } from '@mui/material/styles'
 import { Colors } from './colors'
+import type { ThemeMode } from '@store/themeStore'
 
-export const theme = createTheme({
-  palette: {
-    primary: {
-      main: Colors.primary.main,
-      light: Colors.primary.light,
-      dark: Colors.primary.dark,
-      contrastText: Colors.primary.contrastText,
+/**
+ * Create MUI theme based on theme mode (light/dark)
+ * @param mode - Theme mode ('light' or 'dark')
+ * @returns MUI Theme object
+ */
+export const createAppTheme = (mode: ThemeMode): Theme => {
+  return createTheme({
+    palette: {
+      mode,
+      primary: {
+        main: Colors.primary.main,
+        light: Colors.primary.light,
+        dark: Colors.primary.dark,
+        contrastText: Colors.primary.contrastText,
+      },
+      secondary: {
+        main: Colors.secondary.main,
+        light: Colors.secondary.light,
+        dark: Colors.secondary.dark,
+        contrastText: Colors.secondary.contrastText,
+      },
+      error: {
+        main: Colors.error.main,
+        light: Colors.error.light,
+        dark: Colors.error.dark,
+        contrastText: Colors.error.contrastText,
+      },
+      warning: {
+        main: Colors.warning.main,
+        light: Colors.warning.light,
+        dark: Colors.warning.dark,
+        contrastText: Colors.warning.contrastText,
+      },
+      info: {
+        main: Colors.info.main,
+        light: Colors.info.light,
+        dark: Colors.info.dark,
+        contrastText: Colors.info.contrastText,
+      },
+      success: {
+        main: Colors.success.main,
+        light: Colors.success.light,
+        dark: Colors.success.dark,
+        contrastText: Colors.success.contrastText,
+      },
+      background: {
+        default: Colors.background.default,
+        paper: Colors.background.paper,
+      },
+      text: {
+        primary: Colors.text.primary,
+        secondary: Colors.text.secondary,
+        disabled: Colors.text.disabled,
+      },
     },
-    secondary: {
-      main: Colors.secondary.main,
-      light: Colors.secondary.light,
-      dark: Colors.secondary.dark,
-      contrastText: Colors.secondary.contrastText,
+    typography: {
+      fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
+      h1: {
+        fontSize: '2.5rem',
+        fontWeight: 500,
+      },
+      h2: {
+        fontSize: '2rem',
+        fontWeight: 500,
+      },
+      h3: {
+        fontSize: '1.75rem',
+        fontWeight: 500,
+      },
+      h4: {
+        fontSize: '1.5rem',
+        fontWeight: 500,
+      },
+      h5: {
+        fontSize: '1.25rem',
+        fontWeight: 500,
+      },
+      h6: {
+        fontSize: '1rem',
+        fontWeight: 500,
+      },
     },
-    error: {
-      main: Colors.error.main,
-      light: Colors.error.light,
-      dark: Colors.error.dark,
-      contrastText: Colors.error.contrastText,
-    },
-    warning: {
-      main: Colors.warning.main,
-      light: Colors.warning.light,
-      dark: Colors.warning.dark,
-      contrastText: Colors.warning.contrastText,
-    },
-    info: {
-      main: Colors.info.main,
-      light: Colors.info.light,
-      dark: Colors.info.dark,
-      contrastText: Colors.info.contrastText,
-    },
-    success: {
-      main: Colors.success.main,
-      light: Colors.success.light,
-      dark: Colors.success.dark,
-      contrastText: Colors.success.contrastText,
-    },
-    background: {
-      default: Colors.background.default,
-      paper: Colors.background.paper,
-    },
-    text: {
-      primary: Colors.text.primary,
-      secondary: Colors.text.secondary,
-      disabled: Colors.text.disabled,
-    },
-  },
-  typography: {
-    fontFamily: '"Roboto", "Helvetica", "Arial", sans-serif',
-    h1: {
-      fontSize: '2.5rem',
-      fontWeight: 500,
-    },
-    h2: {
-      fontSize: '2rem',
-      fontWeight: 500,
-    },
-    h3: {
-      fontSize: '1.75rem',
-      fontWeight: 500,
-    },
-    h4: {
-      fontSize: '1.5rem',
-      fontWeight: 500,
-    },
-    h5: {
-      fontSize: '1.25rem',
-      fontWeight: 500,
-    },
-    h6: {
-      fontSize: '1rem',
-      fontWeight: 500,
-    },
-  },
-  components: {
-    MuiButton: {
-      styleOverrides: {
-        root: {
-          textTransform: 'none',
-          borderRadius: 8,
+    components: {
+      MuiButton: {
+        styleOverrides: {
+          root: {
+            textTransform: 'none',
+            borderRadius: 8,
+          },
+        },
+      },
+      MuiCard: {
+        styleOverrides: {
+          root: {
+            borderRadius: 12,
+          },
         },
       },
     },
-    MuiCard: {
-      styleOverrides: {
-        root: {
-          borderRadius: 12,
-        },
-      },
-    },
-  },
-})
+  })
+}
+
+// Default theme (light mode) for backward compatibility
+export const theme = createAppTheme('light')


### PR DESCRIPTION
## 🎯 PR2: Theme Configuration

This is the second PR in the phased dark/light theme implementation.

### Changes
- ✅ Create `createAppTheme()` function that accepts `ThemeMode` parameter
- ✅ Add `mode` parameter to MUI palette configuration
- ✅ Keep existing `theme` export for backward compatibility
- ✅ Import `ThemeMode` type from themeStore
- ✅ Add JSDoc documentation

### Technical Details
- Converts static theme to dynamic function-based theme
- MUI will automatically handle light/dark mode when `mode` is set in palette
- Maintains backward compatibility - existing code using `theme` will continue to work
- Type-safe with TypeScript

### Files Changed
- `augment-store/client/src/config/theme.ts` (updated)

### Usage
```typescript
import { createAppTheme } from '@config/theme'
import { useThemeStore } from '@store/themeStore'

// Create theme based on current mode
const mode = useThemeStore((state) => state.mode)
const theme = createAppTheme(mode)
```

### Next Steps
- PR3: Theme Provider Integration (connect to App.tsx)
- PR4: Theme Toggle Component

**Lines changed:** ~20 lines (net change)
**Part of:** Dark/Light Theme Implementation (Phase 1)

### Dependencies
- Depends on PR1 (Theme Store Setup) for `ThemeMode` type

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author