### PR TITLE
feat(theme): integrate theme store with MUI ThemeProvider

### DIFF
--- a/augment-store/client/src/App.tsx
+++ b/augment-store/client/src/App.tsx
@@ -1,10 +1,17 @@
+import { useMemo } from 'react'
 import { BrowserRouter } from 'react-router-dom'
 import { ThemeProvider } from '@mui/material/styles'
 import CssBaseline from '@mui/material/CssBaseline'
-import { theme } from '@config/theme'
+import { createAppTheme } from '@config/theme'
+import { useThemeStore } from '@store/themeStore'
 import AppRoutes from '@routes/AppRoutes'
 
 function App() {
+  const mode = useThemeStore((state) => state.mode)
+
+  // Create theme based on current mode
+  const theme = useMemo(() => createAppTheme(mode), [mode])
+
   return (
     <ThemeProvider theme={theme}>
       <CssBaseline />


### PR DESCRIPTION
## 🎯 PR3: Theme Provider Integration

This is the third PR in the phased dark/light theme implementation.

### Changes
- ✅ Import `createAppTheme` and `useThemeStore`
- ✅ Subscribe to theme mode from Zustand store
- ✅ Create theme dynamically using `useMemo` for performance
- ✅ Theme now reacts to mode changes automatically

### Technical Details
- Uses `useMemo` to prevent unnecessary theme recreations
- Theme updates automatically when mode changes in store
- MUI's `CssBaseline` will apply appropriate styles for light/dark mode
- No visual changes yet (still defaults to light mode)

### Files Changed
- `augment-store/client/src/App.tsx` (updated)

### How It Works
```typescript
// Subscribe to mode from store
const mode = useThemeStore((state) => state.mode)

// Create theme only when mode changes
const theme = useMemo(() => createAppTheme(mode), [mode])

// Pass to ThemeProvider
<ThemeProvider theme={theme}>
```

### Next Steps
- PR4: Theme Toggle Component (add UI control to switch themes)
- PR5: Theme Persistence & Sync

**Lines changed:** ~8 lines
**Part of:** Dark/Light Theme Implementation (Phase 1)

### Dependencies
- Depends on PR1 (Theme Store Setup)
- Depends on PR2 (Theme Configuration)

### Note
TypeScript errors in this branch are expected - they will resolve when PR1 and PR2 are merged into augment branch.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author