### PR TITLE
feat(theme): add theme toggle component to header

### DIFF
--- a/augment-store/client/src/components/Header.tsx
+++ b/augment-store/client/src/components/Header.tsx
@@ -14,6 +14,7 @@ import { useAuthStore } from '@store/authStore'
 import { useCartStore } from '@store/cartStore'
 import { useUIStore } from '@store/uiStore'
 import SearchBar from '@components/common/SearchBar'
+import ThemeToggle from '@components/ThemeToggle'
 import { authService } from '@services/api/auth/authService'
 
 const Header = () => {
@@ -78,6 +79,9 @@ const Header = () => {
                 <ShoppingCart />
               </Badge>
             </IconButton>
+
+            {/* Theme Toggle - Always Visible */}
+            <ThemeToggle />
 
             {/* Products Button - Hidden on mobile */}
             <Button

--- a/augment-store/client/src/components/ThemeToggle.tsx
+++ b/augment-store/client/src/components/ThemeToggle.tsx
@@ -10,7 +10,9 @@ const ThemeToggle = () => {
       <IconButton
         color="inherit"
         onClick={toggleMode}
-        aria-label={`Switch to ${mode === 'light' ? 'dark' : 'light'} mode`}
+        role="switch"
+        aria-checked={mode === 'dark'}
+        aria-label="Toggle dark mode"
       >
         {mode === 'light' ? <Brightness4 /> : <Brightness7 />}
       </IconButton>
@@ -19,4 +21,3 @@ const ThemeToggle = () => {
 }
 
 export default ThemeToggle
-

--- a/augment-store/client/src/components/ThemeToggle.tsx
+++ b/augment-store/client/src/components/ThemeToggle.tsx
@@ -12,7 +12,7 @@ const ThemeToggle = () => {
         onClick={toggleMode}
         role="switch"
         aria-checked={mode === 'dark'}
-        aria-label="Toggle dark mode"
+        aria-label={`Switch to ${mode === 'light' ? 'dark' : 'light'} mode`}
       >
         {mode === 'light' ? <Brightness4 /> : <Brightness7 />}
       </IconButton>

--- a/augment-store/client/src/components/ThemeToggle.tsx
+++ b/augment-store/client/src/components/ThemeToggle.tsx
@@ -1,0 +1,22 @@
+import { IconButton, Tooltip } from '@mui/material'
+import { Brightness4, Brightness7 } from '@mui/icons-material'
+import { useThemeStore } from '@store/themeStore'
+
+const ThemeToggle = () => {
+  const { mode, toggleMode } = useThemeStore()
+
+  return (
+    <Tooltip title={`Switch to ${mode === 'light' ? 'dark' : 'light'} mode`}>
+      <IconButton
+        color="inherit"
+        onClick={toggleMode}
+        aria-label={`Switch to ${mode === 'light' ? 'dark' : 'light'} mode`}
+      >
+        {mode === 'light' ? <Brightness4 /> : <Brightness7 />}
+      </IconButton>
+    </Tooltip>
+  )
+}
+
+export default ThemeToggle
+

--- a/augment-store/client/src/components/index.ts
+++ b/augment-store/client/src/components/index.ts
@@ -2,3 +2,4 @@
 export { default as Header } from './Header'
 export { default as Footer } from './Footer'
 export { default as Sidebar } from './Sidebar'
+export { default as ThemeToggle } from './ThemeToggle'


### PR DESCRIPTION
## 🎯 PR4: Theme Toggle Component

This is the fourth PR in the phased dark/light theme implementation.

### Changes
- ✅ Create `ThemeToggle` component with light/dark mode icons
- ✅ Add tooltip for better UX ("Switch to dark/light mode")
- ✅ Integrate into Header component (placed after cart icon)
- ✅ Export from components index
- ✅ Always visible on desktop header
- ✅ Accessible with proper aria-label

### Technical Details
- Uses MUI `Brightness4` icon for dark mode (moon)
- Uses MUI `Brightness7` icon for light mode (sun)
- Icon changes based on current theme mode
- Tooltip provides context for the action
- Follows existing Header component patterns

### Files Changed
- `augment-store/client/src/components/ThemeToggle.tsx` (new)
- `augment-store/client/src/components/Header.tsx` (updated)
- `augment-store/client/src/components/index.ts` (updated)

### UI/UX
- **Light mode**: Shows moon icon (Brightness4) - click to switch to dark
- **Dark mode**: Shows sun icon (Brightness7) - click to switch to light
- Tooltip appears on hover
- Positioned between cart and products button

### Next Steps
- PR5: Theme Persistence & Sync (system preference detection)
- PR6: Dark Mode Palette - Core colors

**Lines changed:** ~27 lines
**Part of:** Dark/Light Theme Implementation (Phase 2)

### Dependencies
- Depends on PR1 (Theme Store Setup)
- Depends on PR2 (Theme Configuration)
- Depends on PR3 (Theme Provider Integration)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author