### PR TITLE
feat(wishlist): add type definitions and API endpoints config

### DIFF
--- a/augment-store/client/src/config/api.ts
+++ b/augment-store/client/src/config/api.ts
@@ -60,9 +60,13 @@ export const API_ENDPOINTS = {
     ADD_ADDRESS: '/user/addresses',
     UPDATE_ADDRESS: (id: string) => `/user/addresses/${id}`,
     DELETE_ADDRESS: (id: string) => `/user/addresses/${id}`,
-    WISHLIST: '/user/wishlist',
-    ADD_TO_WISHLIST: '/user/wishlist',
-    REMOVE_FROM_WISHLIST: (id: string) => `/user/wishlist/${id}`,
+  },
+
+  // Wishlist endpoints
+  WISHLIST: {
+    GET: '/wishlist/',
+    ADD: '/wishlist/add/',
+    REMOVE: '/wishlist/remove/',
   },
 
   // Storage endpoints

--- a/augment-store/client/src/features/user/types/index.ts
+++ b/augment-store/client/src/features/user/types/index.ts
@@ -74,3 +74,6 @@ export interface WishlistItem {
   product: Product
   addedAt: string
 }
+
+// Export wishlist types
+export * from './wishlist'

--- a/augment-store/client/src/features/user/types/wishlist.ts
+++ b/augment-store/client/src/features/user/types/wishlist.ts
@@ -1,0 +1,32 @@
+import type { Product } from '@features/products/types'
+
+/**
+ * Wishlist API Types
+ * Backend returns array of products using ProductListSerializer
+ */
+
+// GET /wishlist/ response - array of products
+export type Wishlist = Product[]
+
+// POST /wishlist/add/ request
+export interface AddToWishlistRequest {
+  product_ids: string[] // Array of product UUIDs
+}
+
+// POST /wishlist/add/ response
+export interface AddToWishlistResponse {
+  detail: string
+  product_ids: string[]
+}
+
+// POST /wishlist/remove/ request
+export interface RemoveFromWishlistRequest {
+  product_ids: string[] // Array of product UUIDs
+}
+
+// POST /wishlist/remove/ response
+export interface RemoveFromWishlistResponse {
+  detail: string
+  product_ids: string[]
+}
+


### PR DESCRIPTION
## 📋 Task 1.1: Wishlist Types & API Endpoints Config

This is the **first PR** in a series of 5 PRs to implement the Wishlist GET API integration.

### 🎯 Changes

- ✅ Add wishlist type definitions (`Wishlist`, `AddToWishlistRequest/Response`, `RemoveFromWishlistRequest/Response`)
- ✅ Update `API_ENDPOINTS` config with `WISHLIST` section (GET, ADD, REMOVE endpoints)
- ✅ Export wishlist types from `user/types` module

### 📁 Files Changed (3 files)

1. **`augment-store/client/src/features/user/types/wishlist.ts`** (new)
   - Type definitions for all wishlist API requests and responses
   - Aligned with Django backend serializers

2. **`augment-store/client/src/config/api.ts`** (modified)
   - Added `WISHLIST` section with GET, ADD, REMOVE endpoints
   - Removed old wishlist endpoints from USER section

3. **`augment-store/client/src/features/user/types/index.ts`** (modified)
   - Export wishlist types for use across the application

### 🔗 Backend Integration

Integrates with Django backend endpoints:
- `GET /wishlist/` - List all wishlist products
- `POST /wishlist/add/` - Add products to wishlist
- `POST /wishlist/remove/` - Remove products from wishlist

### 📋 Related Tasks

This PR is part of Task 1 (Wishlist GET API Integration), which is divided into:
- ✅ **Task 1.1**: Types & API Config (this PR)
- ⏳ Task 1.2: Wishlist Service Implementation
- ⏳ Task 1.3: Wishlist Zustand Store
- ⏳ Task 1.4: Wishlist Page Integration & Hook
- ⏳ Task 1.5: Cleanup User Service

### ✅ Testing

- [x] TypeScript compilation passes
- [x] No new linting errors
- [x] Types match backend API structure

### 🚀 Next Steps

After this PR is merged:
- Task 1.2: Implement `wishlistService` with `getWishlist()` method

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author