### PR TITLE
feat(i18n): add translations for recommended products section

### DIFF
--- a/augment-store/client/src/locales/de/translation.json
+++ b/augment-store/client/src/locales/de/translation.json
@@ -102,6 +102,7 @@
     "brand": "Marke",
     "tags": "Tags",
     "relatedProducts": "Ähnliche Produkte",
+    "recommendedProducts": "Empfohlene Produkte",
     "newArrivals": "Neuankömmlinge",
     "bestSellers": "Bestseller",
     "featured": "Empfohlen",

--- a/augment-store/client/src/locales/en/translation.json
+++ b/augment-store/client/src/locales/en/translation.json
@@ -102,6 +102,7 @@
     "brand": "Brand",
     "tags": "Tags",
     "relatedProducts": "Related Products",
+    "recommendedProducts": "Recommended Products",
     "newArrivals": "New Arrivals",
     "bestSellers": "Best Sellers",
     "featured": "Featured",

--- a/augment-store/client/src/locales/es/translation.json
+++ b/augment-store/client/src/locales/es/translation.json
@@ -102,6 +102,7 @@
     "brand": "Marca",
     "tags": "Etiquetas",
     "relatedProducts": "Productos Relacionados",
+    "recommendedProducts": "Productos Recomendados",
     "newArrivals": "Nuevos Productos",
     "bestSellers": "Más Vendidos",
     "featured": "Destacados",

--- a/augment-store/client/src/locales/fr/translation.json
+++ b/augment-store/client/src/locales/fr/translation.json
@@ -102,6 +102,7 @@
     "brand": "Marque",
     "tags": "Étiquettes",
     "relatedProducts": "Produits Connexes",
+    "recommendedProducts": "Produits Recommandés",
     "newArrivals": "Nouveautés",
     "bestSellers": "Meilleures Ventes",
     "featured": "En Vedette",


### PR DESCRIPTION
## Description
Adds internationalization support for the recommended products feature by adding translation keys to all supported language files.

## Changes
- Add `recommendedProducts` translation key to all language files:
  - **English**: "Recommended Products"
  - **Spanish**: "Productos Recomendados"
  - **French**: "Produits Recommandés"
  - **German**: "Empfohlene Produkte"

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [x] Internationalization/Localization

## Testing
- Translation keys added to all 4 supported languages (en, es, fr, de)
- Keys follow existing naming convention under `product.*` namespace

## Dependencies
None - this PR is independent and can be merged separately.

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author