### PR TITLE
feat(notifications): add notification bell component and header integration

### DIFF
--- a/augment-store/client/src/components/Header.tsx
+++ b/augment-store/client/src/components/Header.tsx
@@ -16,6 +16,7 @@ import { useCartStore } from '@store/cartStore'
 import { useUIStore } from '@store/uiStore'
 import SearchBar from '@components/common/SearchBar'
 import SettingsMenu from '@components/SettingsMenu'
+import NotificationBell from '@features/notifications/components/NotificationBell'
 import { authService } from '@services/api/auth/authService'
 import { useTranslation } from '@hooks/useTranslation'
 
@@ -85,6 +86,9 @@ const Header = () => {
                 </Badge>
               </IconButton>
             </Tooltip>
+
+            {/* Notification Bell - Only visible when authenticated */}
+            <NotificationBell />
 
             {/* Settings Menu - Always Visible */}
             <SettingsMenu />

--- a/augment-store/client/src/components/Sidebar.tsx
+++ b/augment-store/client/src/components/Sidebar.tsx
@@ -26,6 +26,7 @@ import {
   Login,
   Receipt,
   HelpOutline,
+  Notifications,
 } from '@mui/icons-material'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
@@ -100,6 +101,11 @@ const Sidebar = () => {
 
   const handleOrdersClick = () => {
     navigate('/orders')
+    closeSidebar()
+  }
+
+  const handleNotificationsClick = () => {
+    navigate('/notifications')
     closeSidebar()
   }
 
@@ -252,6 +258,27 @@ const Sidebar = () => {
                     </ListItemIcon>
                     <ListItemText
                       primary={t('nav.orders')}
+                      primaryTypographyProps={{ fontWeight: 'medium' }}
+                    />
+                  </ListItemButton>
+                </ListItem>
+
+                {/* Notifications */}
+                <ListItem disablePadding>
+                  <ListItemButton
+                    onClick={handleNotificationsClick}
+                    sx={{
+                      py: 1.5,
+                      '&:hover': {
+                        background: 'rgba(255,255,255,0.1)',
+                      },
+                    }}
+                  >
+                    <ListItemIcon sx={{ color: 'white', minWidth: 40 }}>
+                      <Notifications />
+                    </ListItemIcon>
+                    <ListItemText
+                      primary={t('notifications.title')}
                       primaryTypographyProps={{ fontWeight: 'medium' }}
                     />
                   </ListItemButton>

--- a/augment-store/client/src/components/Sidebar.tsx
+++ b/augment-store/client/src/components/Sidebar.tsx
@@ -36,6 +36,7 @@ import { productService } from '@services/api/products/productService'
 import { buildCategoryTree, categoryNameToSlug } from '@utils/categoryUtils'
 import { authService } from '@services/api/auth/authService'
 import type { CategoryWithChildren } from '@features/products/types'
+import { ROUTES } from '@constants/index'
 
 const Sidebar = () => {
   const navigate = useNavigate()
@@ -90,44 +91,44 @@ const Sidebar = () => {
   }
 
   const handleAllProductsClick = () => {
-    navigate('/products')
+    navigate(ROUTES.PRODUCTS)
     closeSidebar()
   }
 
   const handleWishlistClick = () => {
-    navigate('/wishlist')
+    navigate(ROUTES.WISHLIST)
     closeSidebar()
   }
 
   const handleOrdersClick = () => {
-    navigate('/orders')
+    navigate(ROUTES.ORDERS)
     closeSidebar()
   }
 
   const handleNotificationsClick = () => {
-    navigate('/notifications')
+    navigate(ROUTES.NOTIFICATIONS)
     closeSidebar()
   }
 
   const handleProfileClick = () => {
-    navigate('/profile')
+    navigate(ROUTES.PROFILE)
     closeSidebar()
   }
 
   const handleSupportClick = () => {
-    navigate('/support/tickets')
+    navigate(ROUTES.SUPPORT_TICKETS)
     closeSidebar()
   }
 
   const handleLoginClick = () => {
-    navigate('/login')
+    navigate(ROUTES.LOGIN)
     closeSidebar()
   }
 
   const handleLogout = async () => {
     await authService.logout()
     closeSidebar()
-    navigate('/login')
+    navigate(ROUTES.LOGIN)
   }
 
   return (

--- a/augment-store/client/src/constants/index.ts
+++ b/augment-store/client/src/constants/index.ts
@@ -50,6 +50,8 @@ export const PAYMENT_STATUS_LABELS = {
   refunded: 'Refunded',
 } as const
 
+export const POLLING_INTERVAL = 30000 // 30 seconds in milliseconds
+
 export const COUNTRIES = [
   { value: 'AF', label: 'Afghanistan' },
   { value: 'AX', label: 'Åland Islands' },

--- a/augment-store/client/src/constants/index.ts
+++ b/augment-store/client/src/constants/index.ts
@@ -11,6 +11,7 @@ export const ROUTES = {
   ORDER_DETAIL: '/orders/:id',
   PROFILE: '/profile',
   WISHLIST: '/wishlist',
+  NOTIFICATIONS: '/notifications',
   SUPPORT: '/support',
   SUPPORT_TICKETS: '/support/tickets',
   SUPPORT_TICKET_DETAIL: '/support/tickets/:id',

--- a/augment-store/client/src/features/notifications/components/NotificationBell.tsx
+++ b/augment-store/client/src/features/notifications/components/NotificationBell.tsx
@@ -1,0 +1,70 @@
+import { useState, useEffect } from 'react'
+import { IconButton, Badge, Tooltip } from '@mui/material'
+import { Notifications as NotificationsIcon } from '@mui/icons-material'
+import { useNotificationStore } from '@store/notificationStore'
+import { useAuthStore } from '@store/authStore'
+import { useTranslation } from '@hooks/useTranslation'
+import NotificationList from './NotificationList'
+
+const NotificationBell = () => {
+  const { t } = useTranslation()
+  const { isAuthenticated } = useAuthStore()
+  const { unreadCount, fetchNotifications } = useNotificationStore()
+  const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
+  const open = Boolean(anchorEl)
+
+  // Fetch notifications when component mounts (only if authenticated)
+  useEffect(() => {
+    if (isAuthenticated) {
+      fetchNotifications(1, 10)
+    }
+  }, [isAuthenticated, fetchNotifications])
+
+  // Poll for new notifications every 30 seconds
+  useEffect(() => {
+    if (!isAuthenticated) return
+
+    const interval = setInterval(() => {
+      fetchNotifications(1, 10)
+    }, 30000) // 30 seconds
+
+    return () => clearInterval(interval)
+  }, [isAuthenticated, fetchNotifications])
+
+  const handleClick = (event: React.MouseEvent<HTMLElement>) => {
+    setAnchorEl(event.currentTarget)
+  }
+
+  const handleClose = () => {
+    setAnchorEl(null)
+  }
+
+  // Don't render if not authenticated
+  if (!isAuthenticated) {
+    return null
+  }
+
+  return (
+    <>
+      <Tooltip title={t('tooltip.notifications')}>
+        <IconButton
+          color="inherit"
+          onClick={handleClick}
+          aria-label={t('tooltip.notifications')}
+          aria-controls={open ? 'notification-menu' : undefined}
+          aria-haspopup="true"
+          aria-expanded={open ? 'true' : undefined}
+          id="notification-button"
+        >
+          <Badge badgeContent={unreadCount} color="error">
+            <NotificationsIcon />
+          </Badge>
+        </IconButton>
+      </Tooltip>
+      <NotificationList anchorEl={anchorEl} open={open} onClose={handleClose} />
+    </>
+  )
+}
+
+export default NotificationBell
+

--- a/augment-store/client/src/features/notifications/components/NotificationBell.tsx
+++ b/augment-store/client/src/features/notifications/components/NotificationBell.tsx
@@ -4,6 +4,7 @@ import { Notifications as NotificationsIcon } from '@mui/icons-material'
 import { useNotificationStore } from '@store/notificationStore'
 import { useAuthStore } from '@store/authStore'
 import { useTranslation } from '@hooks/useTranslation'
+import { POLLING_INTERVAL } from '@constants/index'
 import NotificationList from './NotificationList'
 
 const NotificationBell = () => {
@@ -26,7 +27,7 @@ const NotificationBell = () => {
 
     const interval = setInterval(() => {
       fetchNotifications(1, 10)
-    }, 30000) // 30 seconds
+    }, POLLING_INTERVAL)
 
     return () => clearInterval(interval)
   }, [isAuthenticated, fetchNotifications])
@@ -67,4 +68,3 @@ const NotificationBell = () => {
 }
 
 export default NotificationBell
-

--- a/augment-store/client/src/features/notifications/components/NotificationList.tsx
+++ b/augment-store/client/src/features/notifications/components/NotificationList.tsx
@@ -1,0 +1,145 @@
+import {
+  Menu,
+  MenuItem,
+  ListItemText,
+  Typography,
+  Box,
+  Divider,
+  Button,
+  CircularProgress,
+} from '@mui/material'
+import { CheckCircle, Circle } from '@mui/icons-material'
+import { useNotificationStore } from '@store/notificationStore'
+import { useNavigate } from 'react-router-dom'
+import { useTranslation } from '@hooks/useTranslation'
+import { formatDistanceToNow } from 'date-fns'
+
+interface NotificationListProps {
+  anchorEl: null | HTMLElement
+  open: boolean
+  onClose: () => void
+}
+
+const NotificationList = ({ anchorEl, open, onClose }: NotificationListProps) => {
+  const { t } = useTranslation()
+  const navigate = useNavigate()
+  const { notifications, isLoading } = useNotificationStore()
+
+  const handleNotificationClick = () => {
+    onClose()
+  }
+
+  const handleViewAll = () => {
+    navigate('/notifications')
+    onClose()
+  }
+
+  const formatNotificationTime = (dateString: string) => {
+    try {
+      return formatDistanceToNow(new Date(dateString), { addSuffix: true })
+    } catch {
+      return dateString
+    }
+  }
+
+  return (
+    <Menu
+      id="notification-menu"
+      anchorEl={anchorEl}
+      open={open}
+      onClose={onClose}
+      MenuListProps={{
+        'aria-labelledby': 'notification-button',
+      }}
+      transformOrigin={{ horizontal: 'right', vertical: 'top' }}
+      anchorOrigin={{ horizontal: 'right', vertical: 'bottom' }}
+      PaperProps={{
+        sx: {
+          width: 360,
+          maxHeight: 480,
+        },
+      }}
+    >
+      {/* Header */}
+      <Box sx={{ px: 2, py: 1.5 }}>
+        <Typography variant="h6" fontWeight="bold">
+          {t('notifications.title')}
+        </Typography>
+      </Box>
+      <Divider />
+
+      {/* Loading State */}
+      {isLoading && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 4 }}>
+          <CircularProgress />
+        </Box>
+      )}
+
+      {/* Empty State */}
+      {!isLoading && notifications.length === 0 && (
+        <Box sx={{ py: 4, textAlign: 'center' }}>
+          <Typography variant="body2" color="text.secondary">
+            {t('notifications.empty')}
+          </Typography>
+        </Box>
+      )}
+
+      {/* Notification Items */}
+      {!isLoading && notifications.length > 0 && (
+        <>
+          {notifications.slice(0, 5).map((notification) => (
+            <MenuItem
+              key={notification.id}
+              onClick={handleNotificationClick}
+              sx={{
+                py: 1.5,
+                px: 2,
+                backgroundColor: notification.isRead ? 'transparent' : 'action.hover',
+                '&:hover': {
+                  backgroundColor: notification.isRead ? 'action.hover' : 'action.selected',
+                },
+              }}
+            >
+              <Box sx={{ mr: 1.5, display: 'flex', alignItems: 'flex-start', pt: 0.5 }}>
+                {notification.isRead ? (
+                  <CheckCircle fontSize="small" color="action" />
+                ) : (
+                  <Circle fontSize="small" color="primary" />
+                )}
+              </Box>
+              <ListItemText
+                primary={
+                  <Typography
+                    variant="body2"
+                    fontWeight={notification.isRead ? 'normal' : 'bold'}
+                    sx={{ mb: 0.5 }}
+                  >
+                    {notification.title}
+                  </Typography>
+                }
+                secondary={
+                  <>
+                    <Typography variant="body2" color="text.secondary" sx={{ mb: 0.5 }}>
+                      {notification.description}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {formatNotificationTime(notification.createdAt)}
+                    </Typography>
+                  </>
+                }
+              />
+            </MenuItem>
+          ))}
+          <Divider />
+          <Box sx={{ p: 1, textAlign: 'center' }}>
+            <Button fullWidth onClick={handleViewAll}>
+              {t('notifications.viewAll')}
+            </Button>
+          </Box>
+        </>
+      )}
+    </Menu>
+  )
+}
+
+export default NotificationList

--- a/augment-store/client/src/features/notifications/components/NotificationList.tsx
+++ b/augment-store/client/src/features/notifications/components/NotificationList.tsx
@@ -13,6 +13,7 @@ import { useNotificationStore } from '@store/notificationStore'
 import { useNavigate } from 'react-router-dom'
 import { useTranslation } from '@hooks/useTranslation'
 import { formatDistanceToNow } from 'date-fns'
+import { ROUTES } from '@constants/index'
 
 interface NotificationListProps {
   anchorEl: null | HTMLElement
@@ -30,7 +31,7 @@ const NotificationList = ({ anchorEl, open, onClose }: NotificationListProps) =>
   }
 
   const handleViewAll = () => {
-    navigate('/notifications')
+    navigate(ROUTES.NOTIFICATIONS)
     onClose()
   }
 

--- a/augment-store/client/src/features/notifications/components/index.ts
+++ b/augment-store/client/src/features/notifications/components/index.ts
@@ -1,0 +1,3 @@
+export { default as NotificationBell } from './NotificationBell'
+export { default as NotificationList } from './NotificationList'
+


### PR DESCRIPTION
## Description
This PR adds the notification bell icon component with dropdown menu and integrates it into the header and sidebar.

## Changes
- Create NotificationBell component with badge showing unread count
- Implement NotificationList dropdown menu showing recent 5 notifications
- Add 30-second polling for new notifications
- Integrate NotificationBell into Header component (desktop)
- Add notifications link to Sidebar for mobile navigation
- Add POLLING_INTERVAL constant for notifications

## Features
- Bell icon with badge showing unread count
- Dropdown menu with recent 5 notifications
- Visual distinction between read/unread notifications (CheckCircle vs Circle icons)
- Relative timestamps using date-fns
- View all button linking to full notifications page
- Auto-refresh every 30 seconds
- Only visible when user is authenticated

## Files Changed
- augment-store/client/src/features/notifications/components/NotificationBell.tsx (new)
- augment-store/client/src/features/notifications/components/NotificationList.tsx (new)
- augment-store/client/src/features/notifications/components/index.ts (new)
- augment-store/client/src/components/Header.tsx (modified)
- augment-store/client/src/components/Sidebar.tsx (modified)
- augment-store/client/src/constants/index.ts (modified)

## Dependencies
- Depends on: PR #212 (API service and types), PR #213 (store)

## Related PRs
- Part 3 of 5 for notifications feature implementation