### PR TITLE
feat(notifications): add notifications page with pagination

### DIFF
--- a/augment-store/client/src/features/notifications/pages/NotificationsPage.tsx
+++ b/augment-store/client/src/features/notifications/pages/NotificationsPage.tsx
@@ -1,0 +1,138 @@
+import { useEffect } from 'react'
+import {
+  Container,
+  Typography,
+  Box,
+  Card,
+  CardContent,
+  Pagination,
+  CircularProgress,
+  Chip,
+} from '@mui/material'
+import { CheckCircle, Circle } from '@mui/icons-material'
+import { useNotificationStore } from '@store/notificationStore'
+import { useTranslation } from '@hooks/useTranslation'
+import { formatDistanceToNow } from 'date-fns'
+
+const NotificationsPage = () => {
+  const { t } = useTranslation()
+  const { notifications, isLoading, page, totalPages, unreadCount, fetchNotifications, setPage } =
+    useNotificationStore()
+
+  useEffect(() => {
+    fetchNotifications(page, 10)
+  }, [page, fetchNotifications])
+
+  const handlePageChange = (_event: React.ChangeEvent<unknown>, value: number) => {
+    setPage(value)
+  }
+
+  const formatNotificationTime = (dateString: string) => {
+    try {
+      return formatDistanceToNow(new Date(dateString), { addSuffix: true })
+    } catch {
+      return dateString
+    }
+  }
+
+  return (
+    <Container maxWidth="md" sx={{ py: 4 }}>
+      {/* Header */}
+      <Box sx={{ mb: 4 }}>
+        <Typography variant="h4" fontWeight="bold" gutterBottom>
+          {t('notifications.title')}
+        </Typography>
+        {unreadCount > 0 && (
+          <Chip
+            label={t('notifications.unreadCount', { count: unreadCount })}
+            color="primary"
+            size="small"
+          />
+        )}
+      </Box>
+
+      {/* Loading State */}
+      {isLoading && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', py: 8 }}>
+          <CircularProgress />
+        </Box>
+      )}
+
+      {/* Empty State */}
+      {!isLoading && notifications.length === 0 && (
+        <Card>
+          <CardContent>
+            <Box sx={{ py: 8, textAlign: 'center' }}>
+              <Typography variant="h6" color="text.secondary" gutterBottom>
+                {t('notifications.empty')}
+              </Typography>
+              <Typography variant="body2" color="text.secondary">
+                {t('notifications.emptyDescription')}
+              </Typography>
+            </Box>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Notification List */}
+      {!isLoading && notifications.length > 0 && (
+        <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {notifications.map((notification) => (
+            <Card
+              key={notification.id}
+              sx={{
+                backgroundColor: notification.isRead ? 'background.paper' : 'action.hover',
+                transition: 'all 0.2s',
+                '&:hover': {
+                  boxShadow: 4,
+                },
+              }}
+            >
+              <CardContent>
+                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2 }}>
+                  <Box sx={{ pt: 0.5 }}>
+                    {notification.isRead ? (
+                      <CheckCircle color="action" />
+                    ) : (
+                      <Circle color="primary" />
+                    )}
+                  </Box>
+                  <Box sx={{ flexGrow: 1 }}>
+                    <Typography
+                      variant="h6"
+                      fontWeight={notification.isRead ? 'normal' : 'bold'}
+                      gutterBottom
+                    >
+                      {notification.title}
+                    </Typography>
+                    <Typography variant="body2" color="text.secondary" paragraph>
+                      {notification.description}
+                    </Typography>
+                    <Typography variant="caption" color="text.secondary">
+                      {formatNotificationTime(notification.createdAt)}
+                    </Typography>
+                  </Box>
+                </Box>
+              </CardContent>
+            </Card>
+          ))}
+        </Box>
+      )}
+
+      {/* Pagination */}
+      {!isLoading && totalPages > 1 && (
+        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
+          <Pagination
+            count={totalPages}
+            page={page}
+            onChange={handlePageChange}
+            color="primary"
+            size="large"
+          />
+        </Box>
+      )}
+    </Container>
+  )
+}
+
+export default NotificationsPage

--- a/augment-store/client/src/features/notifications/pages/index.ts
+++ b/augment-store/client/src/features/notifications/pages/index.ts
@@ -1,0 +1,2 @@
+export { default as NotificationsPage } from './NotificationsPage'
+

--- a/augment-store/client/src/routes/AppRoutes.tsx
+++ b/augment-store/client/src/routes/AppRoutes.tsx
@@ -28,6 +28,9 @@ import TicketDetailPage from '@features/support/ticket-detail/components/TicketD
 import CreateTicketPage from '@features/support/create-ticket/components/CreateTicketPage'
 import TicketsPage from '@features/support/ticket-list/components/TicketsPage'
 
+// Notification pages
+import NotificationsPage from '@features/notifications/pages/NotificationsPage'
+
 // Info pages
 import AboutPage from '@features/info/about/components/AboutPage'
 import ContactPage from '@features/info/contact/components/ContactPage'
@@ -79,6 +82,7 @@ const AppRoutes = () => {
           <Route path="/orders/:id" element={<OrderDetailPage />} />
           <Route path="/profile" element={<ProfilePage />} />
           <Route path="/wishlist" element={<WishlistPage />} />
+          <Route path="/notifications" element={<NotificationsPage />} />
           <Route path="/support/tickets/:id" element={<TicketDetailPage />} />
           <Route path="/support/create" element={<CreateTicketPage />} />
           <Route path="/support/tickets" element={<TicketsPage />} />


### PR DESCRIPTION
## Description
This PR adds a full-page view for notifications with pagination support.

## Changes
- Create NotificationsPage component with full list view
- Display all notifications with read/unread status indicators
- Implement pagination using MUI Pagination component
- Add protected route for /notifications path
- Show unread count chip in page header
- Format notification timestamps with date-fns

## Features
- Full-page notifications list
- Visual distinction between read/unread (CheckCircle vs Circle icons, background color)
- Unread count chip in header
- Pagination controls at bottom
- Relative timestamps (e.g., 2 hours ago)
- Empty state when no notifications
- Loading state with spinner
- Protected route (requires authentication)

## Files Changed
- augment-store/client/src/features/notifications/pages/NotificationsPage.tsx (new)
- augment-store/client/src/features/notifications/pages/index.ts (new)
- augment-store/client/src/routes/AppRoutes.tsx (modified)

## Dependencies
- Depends on: PR #212 (API service and types), PR #213 (store)

## Related PRs
- Part 4 of 5 for notifications feature implementation