### PR TITLE
feat(notifications): add internationalization support

### DIFF
--- a/augment-store/client/src/locales/de/translation.json
+++ b/augment-store/client/src/locales/de/translation.json
@@ -59,7 +59,15 @@
     "logout": "Abmelden",
     "products": "Produkte durchsuchen",
     "login": "Bei Ihrem Konto anmelden",
-    "changeLanguage": "Sprache ändern"
+    "changeLanguage": "Sprache ändern",
+    "notifications": "Benachrichtigungen"
+  },
+  "notifications": {
+    "title": "Benachrichtigungen",
+    "empty": "Noch keine Benachrichtigungen",
+    "emptyDescription": "Sie sehen hier Benachrichtigungen, wenn Sie Updates haben",
+    "viewAll": "Alle Benachrichtigungen anzeigen",
+    "unreadCount": "{{count}} ungelesen"
   },
   "auth": {
     "login": "Anmelden",

--- a/augment-store/client/src/locales/de/translation.json
+++ b/augment-store/client/src/locales/de/translation.json
@@ -67,7 +67,8 @@
     "empty": "Noch keine Benachrichtigungen",
     "emptyDescription": "Sie sehen hier Benachrichtigungen, wenn Sie Updates haben",
     "viewAll": "Alle Benachrichtigungen anzeigen",
-    "unreadCount": "{{count}} ungelesen"
+    "unreadCount": "{{count}} ungelesene Benachrichtigung",
+    "unreadCount_other": "{{count}} ungelesene Benachrichtigungen"
   },
   "auth": {
     "login": "Anmelden",

--- a/augment-store/client/src/locales/en/translation.json
+++ b/augment-store/client/src/locales/en/translation.json
@@ -59,7 +59,15 @@
     "logout": "Logout",
     "products": "Browse products",
     "login": "Login to your account",
-    "changeLanguage": "Change language"
+    "changeLanguage": "Change language",
+    "notifications": "Notifications"
+  },
+  "notifications": {
+    "title": "Notifications",
+    "empty": "No notifications yet",
+    "emptyDescription": "You'll see notifications here when you have updates",
+    "viewAll": "View all notifications",
+    "unreadCount": "{{count}} unread"
   },
   "auth": {
     "login": "Login",

--- a/augment-store/client/src/locales/en/translation.json
+++ b/augment-store/client/src/locales/en/translation.json
@@ -67,7 +67,8 @@
     "empty": "No notifications yet",
     "emptyDescription": "You'll see notifications here when you have updates",
     "viewAll": "View all notifications",
-    "unreadCount": "{{count}} unread"
+    "unreadCount": "{{count}} unread notification",
+    "unreadCount_other": "{{count}} unread notifications"
   },
   "auth": {
     "login": "Login",

--- a/augment-store/client/src/locales/es/translation.json
+++ b/augment-store/client/src/locales/es/translation.json
@@ -67,7 +67,8 @@
     "empty": "No hay notificaciones aún",
     "emptyDescription": "Verás notificaciones aquí cuando tengas actualizaciones",
     "viewAll": "Ver todas las notificaciones",
-    "unreadCount": "{{count}} sin leer"
+    "unreadCount": "{{count}} notificación sin leer",
+    "unreadCount_other": "{{count}} notificaciones sin leer"
   },
   "auth": {
     "login": "Iniciar Sesión",

--- a/augment-store/client/src/locales/es/translation.json
+++ b/augment-store/client/src/locales/es/translation.json
@@ -59,7 +59,15 @@
     "logout": "Cerrar sesión",
     "products": "Explorar productos",
     "login": "Iniciar sesión en tu cuenta",
-    "changeLanguage": "Cambiar idioma"
+    "changeLanguage": "Cambiar idioma",
+    "notifications": "Notificaciones"
+  },
+  "notifications": {
+    "title": "Notificaciones",
+    "empty": "No hay notificaciones aún",
+    "emptyDescription": "Verás notificaciones aquí cuando tengas actualizaciones",
+    "viewAll": "Ver todas las notificaciones",
+    "unreadCount": "{{count}} sin leer"
   },
   "auth": {
     "login": "Iniciar Sesión",

--- a/augment-store/client/src/locales/fr/translation.json
+++ b/augment-store/client/src/locales/fr/translation.json
@@ -59,7 +59,15 @@
     "logout": "Déconnexion",
     "products": "Parcourir les produits",
     "login": "Se connecter à votre compte",
-    "changeLanguage": "Changer de langue"
+    "changeLanguage": "Changer de langue",
+    "notifications": "Notifications"
+  },
+  "notifications": {
+    "title": "Notifications",
+    "empty": "Aucune notification pour le moment",
+    "emptyDescription": "Vous verrez les notifications ici lorsque vous aurez des mises à jour",
+    "viewAll": "Voir toutes les notifications",
+    "unreadCount": "{{count}} non lu(s)"
   },
   "auth": {
     "login": "Connexion",

--- a/augment-store/client/src/locales/fr/translation.json
+++ b/augment-store/client/src/locales/fr/translation.json
@@ -67,7 +67,8 @@
     "empty": "Aucune notification pour le moment",
     "emptyDescription": "Vous verrez les notifications ici lorsque vous aurez des mises à jour",
     "viewAll": "Voir toutes les notifications",
-    "unreadCount": "{{count}} non lu(s)"
+    "unreadCount": "{{count}} notification non lue",
+    "unreadCount_other": "{{count}} notifications non lues"
   },
   "auth": {
     "login": "Connexion",


### PR DESCRIPTION
## Description
This PR adds internationalization support for the notifications feature across all 4 supported languages.

## Changes
- Add notification translations for English (en)
- Add notification translations for Spanish (es)
- Add notification translations for French (fr)
- Add notification translations for German (de)

## Translation Keys Added
- tooltip.notifications: Tooltip for notification bell icon
- notifications.title: Page/section title
- notifications.empty: Empty state message
- notifications.emptyDescription: Empty state description
- notifications.viewAll: View all button text
- notifications.unreadCount: Unread count text with interpolation

## Languages Supported
- 🇬🇧 English
- 🇪🇸 Spanish
- 🇫🇷 French
- 🇩🇪 German

## Files Changed
- augment-store/client/src/locales/en/translation.json (modified)
- augment-store/client/src/locales/es/translation.json (modified)
- augment-store/client/src/locales/fr/translation.json (modified)
- augment-store/client/src/locales/de/translation.json (modified)

## Dependencies
- Can be reviewed independently

## Related PRs
- Part 5 of 5 for notifications feature implementation