### PR TITLE
feat(notifications): implement notification click actions and navigation

### DIFF
--- a/augment-store/client/src/features/notifications/components/NotificationList.tsx
+++ b/augment-store/client/src/features/notifications/components/NotificationList.tsx
@@ -14,6 +14,11 @@ import { useNavigate } from 'react-router-dom'
 import { useTranslation } from '@hooks/useTranslation'
 import { formatDistanceToNow } from 'date-fns'
 import { ROUTES } from '@constants/index'
+import {
+  getNotificationNavigationPath,
+  isNotificationClickable,
+} from '../utils/notificationNavigation'
+import type { Notification } from '../types'
 
 interface NotificationListProps {
   anchorEl: null | HTMLElement
@@ -24,9 +29,20 @@ interface NotificationListProps {
 const NotificationList = ({ anchorEl, open, onClose }: NotificationListProps) => {
   const { t } = useTranslation()
   const navigate = useNavigate()
-  const { notifications, isLoading } = useNotificationStore()
+  const { notifications, isLoading, markAsRead } = useNotificationStore()
 
-  const handleNotificationClick = () => {
+  const handleNotificationClick = (notification: Notification) => {
+    // Mark as read if unread
+    if (!notification.isRead) {
+      markAsRead(notification.id)
+    }
+
+    // Navigate to the related page if available
+    const navigationPath = getNotificationNavigationPath(notification.model, notification.objectId)
+    if (navigationPath) {
+      navigate(navigationPath)
+    }
+
     onClose()
   }
 
@@ -91,7 +107,7 @@ const NotificationList = ({ anchorEl, open, onClose }: NotificationListProps) =>
           {notifications.slice(0, 5).map((notification) => (
             <MenuItem
               key={notification.id}
-              onClick={handleNotificationClick}
+              onClick={() => handleNotificationClick(notification)}
               sx={{
                 py: 1.5,
                 px: 2,
@@ -99,6 +115,9 @@ const NotificationList = ({ anchorEl, open, onClose }: NotificationListProps) =>
                 '&:hover': {
                   backgroundColor: notification.isRead ? 'action.hover' : 'action.selected',
                 },
+                cursor: isNotificationClickable(notification.model, notification.objectId)
+                  ? 'pointer'
+                  : 'default',
               }}
             >
               <Box sx={{ mr: 1.5, display: 'flex', alignItems: 'flex-start', pt: 0.5 }}>

--- a/augment-store/client/src/features/notifications/pages/NotificationsPage.tsx
+++ b/augment-store/client/src/features/notifications/pages/NotificationsPage.tsx
@@ -13,11 +13,26 @@ import { CheckCircle, Circle } from '@mui/icons-material'
 import { useNotificationStore } from '@store/notificationStore'
 import { useTranslation } from '@hooks/useTranslation'
 import { formatDistanceToNow } from 'date-fns'
+import { useNavigate } from 'react-router-dom'
+import {
+  getNotificationNavigationPath,
+  isNotificationClickable,
+} from '../utils/notificationNavigation'
+import type { Notification } from '../types'
 
 const NotificationsPage = () => {
   const { t } = useTranslation()
-  const { notifications, isLoading, page, totalPages, unreadCount, fetchNotifications, setPage } =
-    useNotificationStore()
+  const navigate = useNavigate()
+  const {
+    notifications,
+    isLoading,
+    page,
+    totalPages,
+    unreadCount,
+    fetchNotifications,
+    setPage,
+    markAsRead,
+  } = useNotificationStore()
 
   useEffect(() => {
     fetchNotifications(page, 10)
@@ -25,6 +40,19 @@ const NotificationsPage = () => {
 
   const handlePageChange = (_event: React.ChangeEvent<unknown>, value: number) => {
     setPage(value)
+  }
+
+  const handleNotificationClick = (notification: Notification) => {
+    // Mark as read if unread
+    if (!notification.isRead) {
+      markAsRead(notification.id)
+    }
+
+    // Navigate to the related page if available
+    const navigationPath = getNotificationNavigationPath(notification.model, notification.objectId)
+    if (navigationPath) {
+      navigate(navigationPath)
+    }
   }
 
   const formatNotificationTime = (dateString: string) => {
@@ -77,45 +105,50 @@ const NotificationsPage = () => {
       {/* Notification List */}
       {!isLoading && notifications.length > 0 && (
         <Box sx={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
-          {notifications.map((notification) => (
-            <Card
-              key={notification.id}
-              sx={{
-                backgroundColor: notification.isRead ? 'background.paper' : 'action.hover',
-                transition: 'all 0.2s',
-                '&:hover': {
-                  boxShadow: 4,
-                },
-              }}
-            >
-              <CardContent>
-                <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2 }}>
-                  <Box sx={{ pt: 0.5 }}>
-                    {notification.isRead ? (
-                      <CheckCircle color="action" />
-                    ) : (
-                      <Circle color="primary" />
-                    )}
+          {notifications.map((notification) => {
+            const isClickable = isNotificationClickable(notification.model, notification.objectId)
+            return (
+              <Card
+                key={notification.id}
+                onClick={() => handleNotificationClick(notification)}
+                sx={{
+                  backgroundColor: notification.isRead ? 'background.paper' : 'action.hover',
+                  transition: 'all 0.2s',
+                  cursor: isClickable ? 'pointer' : 'default',
+                  '&:hover': {
+                    boxShadow: isClickable ? 4 : 1,
+                  },
+                }}
+              >
+                <CardContent>
+                  <Box sx={{ display: 'flex', alignItems: 'flex-start', gap: 2 }}>
+                    <Box sx={{ pt: 0.5 }}>
+                      {notification.isRead ? (
+                        <CheckCircle color="action" />
+                      ) : (
+                        <Circle color="primary" />
+                      )}
+                    </Box>
+                    <Box sx={{ flexGrow: 1 }}>
+                      <Typography
+                        variant="h6"
+                        fontWeight={notification.isRead ? 'normal' : 'bold'}
+                        gutterBottom
+                      >
+                        {notification.title}
+                      </Typography>
+                      <Typography variant="body2" color="text.secondary" paragraph>
+                        {notification.description}
+                      </Typography>
+                      <Typography variant="caption" color="text.secondary">
+                        {formatNotificationTime(notification.createdAt)}
+                      </Typography>
+                    </Box>
                   </Box>
-                  <Box sx={{ flexGrow: 1 }}>
-                    <Typography
-                      variant="h6"
-                      fontWeight={notification.isRead ? 'normal' : 'bold'}
-                      gutterBottom
-                    >
-                      {notification.title}
-                    </Typography>
-                    <Typography variant="body2" color="text.secondary" paragraph>
-                      {notification.description}
-                    </Typography>
-                    <Typography variant="caption" color="text.secondary">
-                      {formatNotificationTime(notification.createdAt)}
-                    </Typography>
-                  </Box>
-                </Box>
-              </CardContent>
-            </Card>
-          ))}
+                </CardContent>
+              </Card>
+            )
+          })}
         </Box>
       )}
 

--- a/augment-store/client/src/features/notifications/utils/notificationNavigation.ts
+++ b/augment-store/client/src/features/notifications/utils/notificationNavigation.ts
@@ -1,0 +1,49 @@
+import { ROUTES } from '@constants/index'
+
+/**
+ * Maps notification model types to their corresponding routes
+ */
+const MODEL_ROUTE_MAP: Record<string, (objectId: string) => string> = {
+  order: (objectId) => ROUTES.ORDER_DETAIL.replace(':id', objectId),
+  product: (objectId) => ROUTES.PRODUCT_DETAIL.replace(':id', objectId),
+  supportticket: (objectId) => ROUTES.SUPPORT_TICKET_DETAIL.replace(':id', objectId),
+  ticket: (objectId) => ROUTES.SUPPORT_TICKET_DETAIL.replace(':id', objectId),
+}
+
+/**
+ * Gets the navigation path for a notification based on its model and objectId
+ * @param model - The model type (e.g., 'order', 'product', 'supportticket')
+ * @param objectId - The ID of the object
+ * @returns The navigation path, or null if no route is found
+ */
+export const getNotificationNavigationPath = (
+  model: string | null,
+  objectId: string | null
+): string | null => {
+  if (!model || !objectId) {
+    return null
+  }
+
+  const normalizedModel = model.toLowerCase()
+  const routeGenerator = MODEL_ROUTE_MAP[normalizedModel]
+
+  if (!routeGenerator) {
+    return null
+  }
+
+  return routeGenerator(objectId)
+}
+
+/**
+ * Checks if a notification is clickable (has a valid navigation path)
+ * @param model - The model type
+ * @param objectId - The ID of the object
+ * @returns True if the notification is clickable, false otherwise
+ */
+export const isNotificationClickable = (
+  model: string | null,
+  objectId: string | null
+): boolean => {
+  return getNotificationNavigationPath(model, objectId) !== null
+}
+


### PR DESCRIPTION
## Summary
Implements click actions for notifications, making them interactive and navigable to related pages.

## Changes
- ✅ Created `notificationNavigation` utility to map notification models to routes
- ✅ Added click handlers to NotificationList dropdown items
- ✅ Added click handlers to NotificationsPage notification cards
- ✅ Automatically mark notifications as read when clicked
- ✅ Navigate to related pages (orders, products, support tickets) based on notification model
- ✅ Added visual feedback (cursor pointer) for clickable notifications
- ✅ Support model types: `order`, `product`, `supportticket`/`ticket`
- ✅ Gracefully handle notifications without navigation targets

## User Experience Improvements
- Notifications are now actionable - clicking navigates to the relevant page
- Visual cursor feedback indicates which notifications are clickable
- Notifications are automatically marked as read when clicked
- Seamless navigation from notification to order details, product pages, or support tickets
- Non-clickable notifications (without model/objectId) remain functional but don't navigate

## Technical Details

### Supported Navigation Mappings
- `order` → `/orders/:id`
- `product` → `/products/:id`
- `supportticket` or `ticket` → `/support/tickets/:id`

### Utility Functions
```typescript
getNotificationNavigationPath(model, objectId) // Returns path or null
isNotificationClickable(model, objectId) // Returns boolean
```

## Testing
- Click on notifications in the dropdown menu
- Click on notifications in the notifications page
- Verify navigation to correct pages
- Verify notifications are marked as read after clicking
- Test with different notification types (orders, products, tickets)

## Related Issues
Part of frontend improvements initiative - no backend changes required

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author