### PR TITLE
fix: Fix file update owner field

### DIFF
--- a/augment-store/server/storage/services.py
+++ b/augment-store/server/storage/services.py
@@ -98,8 +98,7 @@ class FileStandardUploadService:
         file.original_file_name = file_name
         file.file_name = file_generate_name(file_name)
         file.file_type = file_type
-        file.uploaded_by = self.user
-        file.upload_finished_at = timezone.now()
+        file.created_by = self.user
 
         file.full_clean()
         file.save()

--- a/augment-store/server/storage/services.py
+++ b/augment-store/server/storage/services.py
@@ -99,6 +99,7 @@ class FileStandardUploadService:
         file.file_name = file_generate_name(file_name)
         file.file_type = file_type
         file.created_by = self.user
+        file.upload_finished_at = timezone.now()
 
         file.full_clean()
         file.save()

--- a/augment-store/server/storage/tests.py
+++ b/augment-store/server/storage/tests.py
@@ -7,6 +7,7 @@ from django.core.files.uploadedfile import SimpleUploadedFile
 from storage.models import File
 from django.test import override_settings
 from django.conf import settings
+from storage.services import FileStandardUploadService
 import os
 
 
@@ -339,6 +340,22 @@ class StorageTests(BaseAPITestCase):
 
         # THEN we should get a 400 response
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_standard_upload_update_changes_owner(self):
+        file_record = File.objects.create(
+            original_file_name="old.jpg",
+            file_name="old.jpg",
+            file_type="image/jpeg",
+            created_by=self.merchant_user,
+        )
+
+        service = FileStandardUploadService(
+            self.member_user,
+            SimpleUploadedFile("new.jpg", b"file_content", content_type="image/jpeg"),
+        )
+        updated_file = service.update(file_record)
+
+        self.assertEqual(updated_file.created_by, self.member_user)
 
 import tempfile
 import shutil

--- a/augment-store/server/storage/tests.py
+++ b/augment-store/server/storage/tests.py
@@ -354,8 +354,10 @@ class StorageTests(BaseAPITestCase):
             SimpleUploadedFile("new.jpg", b"file_content", content_type="image/jpeg"),
         )
         updated_file = service.update(file_record)
+        self.addCleanup(updated_file.file.delete, save=False)
 
         self.assertEqual(updated_file.created_by, self.member_user)
+        self.assertIsNotNone(updated_file.upload_finished_at)
 
 import tempfile
 import shutil


### PR DESCRIPTION
Fixes file update ownership metadata.

Changes:
- Update FileStandardUploadService.update to write the real created_by field.
- Preserve upload_finished_at when replacing the stored file.
- Add regression coverage for owner transfer and completion state.

Checklist:
- [x] My code follows the code style of this project.
- [x] This PR does not contain plagiarized content.
- [x] The title and description of the PR is clear and explains the approach.