### PR TITLE
fix: preserve updated payment amount

### DIFF
--- a/augment-store/server/checkout/serializers.py
+++ b/augment-store/server/checkout/serializers.py
@@ -266,7 +266,7 @@ class OrderPaymentSerializer(serializers.ModelSerializer):
         try:
             payment = order.payment
             Payment.objects.filter(id=payment.id).update(amount=amount, payment_method=payment_method)
-            payment.refresh_from_db(fields=["amount"])
+            payment.refresh_from_db(fields=["amount", "payment_method"])
         except Payment.DoesNotExist:
             payment = Payment.objects.create(
                 order=order, 

--- a/augment-store/server/checkout/serializers.py
+++ b/augment-store/server/checkout/serializers.py
@@ -266,6 +266,7 @@ class OrderPaymentSerializer(serializers.ModelSerializer):
         try:
             payment = order.payment
             Payment.objects.filter(id=payment.id).update(amount=amount, payment_method=payment_method)
+            payment.refresh_from_db(fields=["amount"])
         except Payment.DoesNotExist:
             payment = Payment.objects.create(
                 order=order, 

--- a/augment-store/server/checkout/tests.py
+++ b/augment-store/server/checkout/tests.py
@@ -790,6 +790,7 @@ class OrderPaymentTest(BaseAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         order.payment.refresh_from_db()
         self.assertEqual(order.payment.amount, order.total)
+        self.assertEqual(order.payment.payment_method, Payment.PaymentMethod.STRIPE)
 
 
 

--- a/augment-store/server/checkout/tests.py
+++ b/augment-store/server/checkout/tests.py
@@ -770,6 +770,12 @@ class OrderPaymentTest(BaseAPITestCase):
         order = OrderFactory(created_by=self.user)
         cart_item = CartItemFactory(quantity=1)
         OrderItemFactory(order=order, cart_item=cart_item)
+        PaymentFactory(
+            order=order,
+            created_by=self.user,
+            amount=Decimal("1.00"),
+            payment_method=Payment.PaymentMethod.CASH_ON_DELIVERY,
+        )
 
         # WHEN I make a payment for the order
         url = reverse("v1:checkout_payments:payment_order")
@@ -782,6 +788,8 @@ class OrderPaymentTest(BaseAPITestCase):
 
         # THEN we should get a 201 response
         self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        order.payment.refresh_from_db()
+        self.assertEqual(order.payment.amount, order.total)
 
 
 

--- a/augment-store/server/checkout/tests.py
+++ b/augment-store/server/checkout/tests.py
@@ -774,7 +774,7 @@ class OrderPaymentTest(BaseAPITestCase):
             order=order,
             created_by=self.user,
             amount=Decimal("1.00"),
-            payment_method=Payment.PaymentMethod.CASH_ON_DELIVERY,
+            payment_method=Payment.PaymentMethod.PAYPAL,
         )
 
         # WHEN I make a payment for the order


### PR DESCRIPTION
## Summary
- keep existing-payment fields in sync before Stripe session creation
- prevent stale in-memory payment method from being persisted during follow-up save
- extend regression coverage for repayment flow to assert updated payment method

## Notes
- scope is checkout payment serializer behavior and checkout API tests only