### PR TITLE
fix: reject empty checkout orders

### DIFF
--- a/augment-store/server/checkout/serializers.py
+++ b/augment-store/server/checkout/serializers.py
@@ -94,8 +94,10 @@ class CreateOrderSerializer(serializers.ModelSerializer):
         user = self.context.get("request").user
         if not value:
             raise serializers.ValidationError("cart_items cannot be empty")
+        if len(value) != len(set(value)):
+            raise serializers.ValidationError("cart_items must not contain duplicates")
         cart_items = CartItem.objects.get_user_cart_items(user).filter(id__in=value)
-        if cart_items.count() != len(set(value)):
+        if cart_items.count() != len(value):
             raise serializers.ValidationError("One or more cart items do not exist")
         return cart_items
     

--- a/augment-store/server/checkout/serializers.py
+++ b/augment-store/server/checkout/serializers.py
@@ -92,8 +92,10 @@ class CreateOrderSerializer(serializers.ModelSerializer):
 
     def validate_cart_items(self, value):
         user = self.context.get("request").user
+        if not value:
+            raise serializers.ValidationError("cart_items cannot be empty")
         cart_items = CartItem.objects.get_user_cart_items(user).filter(id__in=value)
-        if cart_items.count() != len(value):
+        if cart_items.count() != len(set(value)):
             raise serializers.ValidationError("One or more cart items do not exist")
         return cart_items
     

--- a/augment-store/server/checkout/tests.py
+++ b/augment-store/server/checkout/tests.py
@@ -111,6 +111,29 @@ class CreateOrderViewTests(BaseAPITestCase):
         # AND no order should be created
         self.assertEqual(Order.objects.count(), 0)
 
+    def test_create_order_with_duplicate_cart_items(self):
+        # GIVEN an authenticated user exists
+        cart_item = CartItemFactory(
+            product=self.product1,
+            quantity=1,
+            created_by=self.member_user
+        )
+
+        # WHEN we make a POST request with duplicate cart item IDs
+        url = reverse("v1:checkout:create_order")
+        payload = {
+            "cart_items": [str(cart_item.id), str(cart_item.id)]
+        }
+        response = self.member_client.post(url, payload, format='json')
+
+        # THEN we should get a 400 response with duplicate validation error
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("cart_items", response.data)
+        self.assertIn("must not contain duplicates", response.data["cart_items"][0])
+
+        # AND no order should be created
+        self.assertEqual(Order.objects.count(), 0)
+
     def test_create_order_with_invalid_cart_item_id(self):
         # GIVEN an authenticated user exists
 

--- a/augment-store/server/checkout/tests.py
+++ b/augment-store/server/checkout/tests.py
@@ -103,12 +103,11 @@ class CreateOrderViewTests(BaseAPITestCase):
         }
         response = self.member_client.post(url, payload, format='json')
 
-        # THEN we should get a 201 response (order created but empty)
-        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        # THEN we should get a 400 response
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-        # AND an order should be created with no items
-        order = Order.objects.first()
-        self.assertEqual(order.items.count(), 0)
+        # AND no order should be created
+        self.assertEqual(Order.objects.count(), 0)
 
     def test_create_order_with_invalid_cart_item_id(self):
         # GIVEN an authenticated user exists

--- a/augment-store/server/checkout/tests.py
+++ b/augment-store/server/checkout/tests.py
@@ -105,6 +105,8 @@ class CreateOrderViewTests(BaseAPITestCase):
 
         # THEN we should get a 400 response
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("cart_items", response.data)
+        self.assertIn("cannot be empty", response.data["cart_items"][0])
 
         # AND no order should be created
         self.assertEqual(Order.objects.count(), 0)


### PR DESCRIPTION
## Summary
- reject checkout requests when cart_items is empty
- reject duplicate cart item ids so request semantics are explicit
- strengthen regression coverage to assert cart_items validation errors

## Notes
- scope is checkout serializer validation and related API tests only