### PR TITLE
fix: reject deleted products in checkout

### DIFF
--- a/augment-store/server/checkout/serializers.py
+++ b/augment-store/server/checkout/serializers.py
@@ -191,8 +191,15 @@ class CreateOrderSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         user = self.context.get("request").user
+        requested_cart_item_ids = self.initial_data.get("cart_items", [])
         with transaction.atomic():
-            cart_items = list(validated_data.get("cart_items").select_for_update())
+            cart_items = list(
+                CartItem.objects.get_user_cart_items(user)
+                .select_for_update()
+                .filter(id__in=requested_cart_item_ids)
+            )
+            if len(cart_items) != len(requested_cart_item_ids):
+                raise serializers.ValidationError({"cart_items": ["One or more cart items do not exist"]})
             if any(cart_item.product_id is None for cart_item in cart_items):
                 raise serializers.ValidationError({"cart_items": ["One or more cart items have no associated product"]})
 

--- a/augment-store/server/checkout/serializers.py
+++ b/augment-store/server/checkout/serializers.py
@@ -99,7 +99,7 @@ class CreateOrderSerializer(serializers.ModelSerializer):
         cart_items = CartItem.objects.get_user_cart_items(user).filter(id__in=value)
         if cart_items.count() != len(value):
             raise serializers.ValidationError("One or more cart items do not exist")
-        if not cart_items.filter(product__isnull=False).exists():
+        if cart_items.filter(product__isnull=True).exists():
             raise serializers.ValidationError("One or more cart items have no associated product")
         return cart_items
     

--- a/augment-store/server/checkout/serializers.py
+++ b/augment-store/server/checkout/serializers.py
@@ -194,7 +194,7 @@ class CreateOrderSerializer(serializers.ModelSerializer):
         with transaction.atomic():
             cart_items = list(validated_data.get("cart_items").select_for_update())
             if any(cart_item.product_id is None for cart_item in cart_items):
-                raise serializers.ValidationError("One or more cart items have no associated product")
+                raise serializers.ValidationError({"cart_items": ["One or more cart items have no associated product"]})
 
             order = Order.objects.create(
                 created_by=user,

--- a/augment-store/server/checkout/serializers.py
+++ b/augment-store/server/checkout/serializers.py
@@ -97,12 +97,13 @@ class CreateOrderSerializer(serializers.ModelSerializer):
             raise serializers.ValidationError("cart_items cannot be empty")
         if len(value) != len(set(value)):
             raise serializers.ValidationError("cart_items must not contain duplicates")
-        cart_items = CartItem.objects.get_user_cart_items(user).filter(id__in=value)
-        if cart_items.count() != len(value):
+        requested_cart_item_ids = list(value)
+        cart_items = CartItem.objects.get_user_cart_items(user).filter(id__in=requested_cart_item_ids)
+        if cart_items.count() != len(requested_cart_item_ids):
             raise serializers.ValidationError("One or more cart items do not exist")
         if cart_items.filter(product__isnull=True).exists():
             raise serializers.ValidationError("One or more cart items have no associated product")
-        return cart_items
+        return requested_cart_item_ids
     
 
     def validate_shipping_address(self, value):
@@ -191,7 +192,9 @@ class CreateOrderSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         user = self.context.get("request").user
-        requested_cart_item_ids = list(validated_data.get("cart_items").values_list("id", flat=True))
+        requested_cart_item_ids = list(validated_data.get("cart_items") or [])
+        if len(requested_cart_item_ids) != len(set(requested_cart_item_ids)):
+            raise serializers.ValidationError({"cart_items": ["cart_items must not contain duplicates"]})
         with transaction.atomic():
             cart_items = list(
                 CartItem.objects.get_user_cart_items(user)

--- a/augment-store/server/checkout/serializers.py
+++ b/augment-store/server/checkout/serializers.py
@@ -99,6 +99,8 @@ class CreateOrderSerializer(serializers.ModelSerializer):
         cart_items = CartItem.objects.get_user_cart_items(user).filter(id__in=value)
         if cart_items.count() != len(value):
             raise serializers.ValidationError("One or more cart items do not exist")
+        if not cart_items.filter(product__isnull=False).exists():
+            raise serializers.ValidationError("One or more cart items have no associated product")
         return cart_items
     
 

--- a/augment-store/server/checkout/serializers.py
+++ b/augment-store/server/checkout/serializers.py
@@ -1,5 +1,6 @@
 
 from rest_framework import serializers
+from django.db import transaction
 from .models import Order, OrderItem, Payment, ShippingAddress, BillingAddress, ContactInformation
 from carts.models import CartItem
 from products.serializers import ProductListSerializer
@@ -189,23 +190,27 @@ class CreateOrderSerializer(serializers.ModelSerializer):
         return attrs
 
     def create(self, validated_data):
-
         user = self.context.get("request").user
-        order = Order.objects.create(
-            created_by=user,
-            shipping_address=validated_data.get("shipping_address_id") or validated_data.get("shipping_address"), 
-            billing_address= validated_data.get("billing_address_id") or validated_data.get("billing_address"),
-            contact_information= validated_data.get("contact_information_id") or validated_data.get("contact_information"),
-        )
+        with transaction.atomic():
+            cart_items = list(validated_data.get("cart_items").select_for_update())
+            if any(cart_item.product_id is None for cart_item in cart_items):
+                raise serializers.ValidationError("One or more cart items have no associated product")
 
-        for cart_item in validated_data.get("cart_items"):
-            OrderItem.objects.create(
-                order=order, 
-                product=cart_item.product,
-                quantity=cart_item.quantity,
-                cart_item=cart_item,
+            order = Order.objects.create(
                 created_by=user,
+                shipping_address=validated_data.get("shipping_address_id") or validated_data.get("shipping_address"), 
+                billing_address= validated_data.get("billing_address_id") or validated_data.get("billing_address"),
+                contact_information= validated_data.get("contact_information_id") or validated_data.get("contact_information"),
             )
+
+            for cart_item in cart_items:
+                OrderItem.objects.create(
+                    order=order, 
+                    product=cart_item.product,
+                    quantity=cart_item.quantity,
+                    cart_item=cart_item,
+                    created_by=user,
+                )
 
         return order
 

--- a/augment-store/server/checkout/serializers.py
+++ b/augment-store/server/checkout/serializers.py
@@ -191,7 +191,7 @@ class CreateOrderSerializer(serializers.ModelSerializer):
 
     def create(self, validated_data):
         user = self.context.get("request").user
-        requested_cart_item_ids = self.initial_data.get("cart_items", [])
+        requested_cart_item_ids = list(validated_data.get("cart_items").values_list("id", flat=True))
         with transaction.atomic():
             cart_items = list(
                 CartItem.objects.get_user_cart_items(user)

--- a/augment-store/server/checkout/tests.py
+++ b/augment-store/server/checkout/tests.py
@@ -157,10 +157,13 @@ class CreateOrderViewTests(BaseAPITestCase):
             created_by=self.member_user
         )
         self.product1.delete()
+        cart_item.refresh_from_db()
         url = reverse("v1:checkout:create_order")
         payload = {"cart_items": [str(cart_item.id)]}
         response = self.member_client.post(url, payload, format="json")
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIsNone(cart_item.product)
+        self.assertIn("One or more cart items have no associated product", str(response.data))
         self.assertEqual(Order.objects.count(), 0)
 
     def test_create_order_unauthenticated(self):

--- a/augment-store/server/checkout/tests.py
+++ b/augment-store/server/checkout/tests.py
@@ -150,6 +150,19 @@ class CreateOrderViewTests(BaseAPITestCase):
         # AND no order should be created
         self.assertEqual(Order.objects.count(), 0)
 
+    def test_create_order_with_deleted_product_cart_item(self):
+        cart_item = CartItemFactory(
+            product=self.product1,
+            quantity=1,
+            created_by=self.member_user
+        )
+        self.product1.delete()
+        url = reverse("v1:checkout:create_order")
+        payload = {"cart_items": [str(cart_item.id)]}
+        response = self.member_client.post(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(Order.objects.count(), 0)
+
     def test_create_order_unauthenticated(self):
         # GIVEN a user is not authenticated
         cart_item = CartItemFactory(


### PR DESCRIPTION
## Summary
- validate checkout cart items and reject items whose product is missing
- add regression coverage for deleted-product cart items to ensure checkout fails early

## Risk
- low, scoped to checkout order validation path