### PR TITLE
fix: recheck stock during checkout

### DIFF
--- a/augment-store/server/checkout/serializers.py
+++ b/augment-store/server/checkout/serializers.py
@@ -98,11 +98,16 @@ class CreateOrderSerializer(serializers.ModelSerializer):
         if len(value) != len(set(value)):
             raise serializers.ValidationError("cart_items must not contain duplicates")
         requested_cart_item_ids = list(value)
-        cart_items = CartItem.objects.get_user_cart_items(user).filter(id__in=requested_cart_item_ids)
+        cart_items = CartItem.objects.get_user_cart_items(user).select_related("product").filter(
+            id__in=requested_cart_item_ids
+        )
         if cart_items.count() != len(requested_cart_item_ids):
             raise serializers.ValidationError("One or more cart items do not exist")
-        if cart_items.filter(product__isnull=True).exists():
-            raise serializers.ValidationError("One or more cart items have no associated product")
+        for cart_item in cart_items:
+            if cart_item.product is None:
+                raise serializers.ValidationError("One or more cart items have no associated product")
+            if not cart_item.product.check_stock(cart_item.quantity):
+                raise serializers.ValidationError("One or more cart items are out of stock")
         return requested_cart_item_ids
     
 
@@ -205,6 +210,8 @@ class CreateOrderSerializer(serializers.ModelSerializer):
                 raise serializers.ValidationError({"cart_items": ["One or more cart items do not exist"]})
             if any(cart_item.product_id is None for cart_item in cart_items):
                 raise serializers.ValidationError({"cart_items": ["One or more cart items have no associated product"]})
+            if any(not cart_item.product.check_stock(cart_item.quantity) for cart_item in cart_items):
+                raise serializers.ValidationError({"cart_items": ["One or more cart items are out of stock"]})
 
             order = Order.objects.create(
                 created_by=user,

--- a/augment-store/server/checkout/tests.py
+++ b/augment-store/server/checkout/tests.py
@@ -154,7 +154,7 @@ class CreateOrderViewTests(BaseAPITestCase):
         cart_item = CartItemFactory(
             product=self.product1,
             quantity=1,
-            created_by=self.member_user
+            created_by=self.member_user,
         )
         self.product1.delete()
         cart_item.refresh_from_db()
@@ -164,6 +164,21 @@ class CreateOrderViewTests(BaseAPITestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIsNone(cart_item.product)
         self.assertIn("One or more cart items have no associated product", str(response.data))
+        self.assertEqual(Order.objects.count(), 0)
+
+    def test_create_order_with_stale_cart_quantity(self):
+        cart_item = CartItemFactory(
+            product=self.product1,
+            quantity=3,
+            created_by=self.member_user,
+        )
+        self.product1.quantity = 2
+        self.product1.save(update_fields=["quantity"])
+        url = reverse("v1:checkout:create_order")
+        payload = {"cart_items": [str(cart_item.id)]}
+        response = self.member_client.post(url, payload, format="json")
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("One or more cart items are out of stock", str(response.data))
         self.assertEqual(Order.objects.count(), 0)
 
     def test_create_order_unauthenticated(self):


### PR DESCRIPTION
## Summary
- validate checkout cart items against current product stock
- reject checkout when a cart item quantity exceeds live inventory
- include regression coverage for stale cart quantities

## Risk
- low, scoped to checkout order validation behavior