### PR TITLE
feat(notificationService): add the mark all notifications as read endpoint

### DIFF
--- a/augment-store/client/src/config/api.ts
+++ b/augment-store/client/src/config/api.ts
@@ -117,6 +117,7 @@ export const API_ENDPOINTS = {
   NOTIFICATIONS: {
     LIST: '/notifications/',
     MARK_AS_READ: (id: string) => `/notifications/${id}/`,
+    MARK_ALL_AS_READ: '/notifications/mark-all-as-read/',
     UNREAD_COUNT: '/notifications/unread-count/',
   },
 

--- a/augment-store/client/src/features/notifications/types/index.ts
+++ b/augment-store/client/src/features/notifications/types/index.ts
@@ -70,3 +70,22 @@ export interface MarkAsReadResponse {
 export interface UnreadCountResponse {
   unread_count: number
 }
+
+/**
+ * Mark All as Read Request
+ */
+export interface MarkAllAsReadRequest {
+  mark_all_as_read?: boolean
+  notification_ids?: string[]
+}
+
+/**
+ * Mark All as Read Response
+ */
+export interface MarkAllAsReadResponse {
+  count: number
+  notifications: Array<{
+    id: string
+    is_read: boolean
+  }>
+}

--- a/augment-store/client/src/services/api/notifications/notificationService.ts
+++ b/augment-store/client/src/services/api/notifications/notificationService.ts
@@ -93,6 +93,24 @@ export const notificationService = {
     notificationIds?: string[]
   }): Promise<MarkAllAsReadResponse> => {
     try {
+      // Validate that exactly one option is provided
+      const hasMarkAllAsRead = options.markAllAsRead === true
+      const hasNotificationIds =
+        options.notificationIds !== undefined &&
+        options.notificationIds.length > 0
+
+      if (!hasMarkAllAsRead && !hasNotificationIds) {
+        throw new Error(
+          'Either markAllAsRead must be true or notificationIds array must be provided with at least one ID'
+        )
+      }
+
+      if (hasMarkAllAsRead && hasNotificationIds) {
+        throw new Error(
+          'Cannot provide both markAllAsRead and notificationIds - only one option is allowed'
+        )
+      }
+
       const requestData: MarkAllAsReadRequest = {
         mark_all_as_read: options.markAllAsRead,
         notification_ids: options.notificationIds,

--- a/augment-store/client/src/services/api/notifications/notificationService.ts
+++ b/augment-store/client/src/services/api/notifications/notificationService.ts
@@ -7,6 +7,8 @@ import type {
   NotificationListResponse,
   MarkAsReadRequest,
   MarkAsReadResponse,
+  MarkAllAsReadRequest,
+  MarkAllAsReadResponse,
   UnreadCountResponse,
 } from '@features/notifications/types'
 
@@ -74,6 +76,34 @@ export const notificationService = {
       return response
     } catch (error) {
       console.error('Failed to mark notification as read:', error)
+      throw error
+    }
+  },
+
+  /**
+   * Mark all notifications as read or mark specific notifications as read
+   * @param options - Options for marking notifications as read
+   * @param options.markAllAsRead - If true, marks all notifications as read
+   * @param options.notificationIds - Array of notification IDs to mark as read
+   * @returns Response containing count and array of updated notifications
+   * @note Either markAllAsRead or notificationIds must be provided, but not both
+   */
+  markAllAsRead: async (options: {
+    markAllAsRead?: boolean
+    notificationIds?: string[]
+  }): Promise<MarkAllAsReadResponse> => {
+    try {
+      const requestData: MarkAllAsReadRequest = {
+        mark_all_as_read: options.markAllAsRead,
+        notification_ids: options.notificationIds,
+      }
+      const response = await apiClient.patch<MarkAllAsReadResponse>(
+        API_ENDPOINTS.NOTIFICATIONS.MARK_ALL_AS_READ,
+        requestData
+      )
+      return response
+    } catch (error) {
+      console.error('Failed to mark notifications as read:', error)
       throw error
     }
   },


### PR DESCRIPTION
## Summary

This PR add the mark all notifications as read endpoint

## Changes Made

### Service
- **notificationService** - add the mark all notifications as read endpoint

## How It Works

## Testing

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author