### PR TITLE
fix: invalidate product search cache

### DIFF
--- a/augment-store/server/products/views.py
+++ b/augment-store/server/products/views.py
@@ -242,8 +242,7 @@ class ProductUpdateDeleteView(CacheInvalidatorMixin, BaseProductView, RetrieveUp
     def invalidate_cache(self):
         super().invalidate_cache()
         FeaturedProductCacheService().clear_namespace()
-        if self.request.method == "PUT":
-            ProductSearchCacheService().clear_namespace()
+        ProductSearchCacheService().clear_namespace()
 
     def get_permissions(self):
         if self.request.method in SAFE_METHODS:

--- a/augment-store/server/products/views.py
+++ b/augment-store/server/products/views.py
@@ -242,6 +242,8 @@ class ProductUpdateDeleteView(CacheInvalidatorMixin, BaseProductView, RetrieveUp
     def invalidate_cache(self):
         super().invalidate_cache()
         FeaturedProductCacheService().clear_namespace()
+        if self.request.method == "PUT":
+            ProductSearchCacheService().clear_namespace()
 
     def get_permissions(self):
         if self.request.method in SAFE_METHODS:


### PR DESCRIPTION
Problem
- Product update/delete clears product and featured product caches, but cached product search results can remain stale after product changes.

Fix
- Clear the product search cache from the product update/delete invalidation path.

Validation performed
- git diff --check -- augment-store/server/products/views.py
- Could not run Django tests because python and python3 are not installed in this environment.

Risk/notes
- Small backend-only cache invalidation change scoped to augment-store/server/products/views.py.