### PR TITLE
fix: validate product image ownership

### DIFF
--- a/augment-store/server/products/serializers.py
+++ b/augment-store/server/products/serializers.py
@@ -11,6 +11,13 @@ class CreateProductBrandSerializer(serializers.ModelSerializer):
         model = ProductBrand
         fields = ["name", "description" , "image"]
 
+    def validate_image(self, value):
+        request = self.context.get("request")
+        user = getattr(request, "user", None)
+        if value and value.created_by_id != user.id:
+            raise serializers.ValidationError("Image is invalid")
+        return value
+
     def validate(self, attrs):
         request = self.context.get("request")
         attrs["created_by"] = request.user
@@ -43,7 +50,11 @@ class CreateProductCategorySerializer(serializers.ModelSerializer):
         if parent and parent.is_child_node():
             raise serializers.ValidationError("Parent category cannot be a child category")
         
+        image = attrs.get("image")
         request = self.context.get("request")
+        if image and image.created_by_id != request.user.pk:
+            raise serializers.ValidationError({"image": "Image is invalid"})
+
         attrs["created_by"] = request.user
         return attrs
 

--- a/augment-store/server/products/serializers.py
+++ b/augment-store/server/products/serializers.py
@@ -6,7 +6,7 @@ from accounts.serializers import UserListSerializer
 
 def validate_owned_image(value, request):
     user = getattr(request, "user", None)
-    if value and (not user or value.created_by_id != user.id):
+    if value and (not user or getattr(user, "is_anonymous", True) or value.created_by_id != user.id):
         raise serializers.ValidationError("Image is invalid")
     return value
 

--- a/augment-store/server/products/serializers.py
+++ b/augment-store/server/products/serializers.py
@@ -4,6 +4,13 @@ from storage.serializers import FileListSerializer
 from accounts.serializers import UserListSerializer
 
 
+def validate_owned_image(value, request):
+    user = getattr(request, "user", None)
+    if value and (not user or value.created_by_id != user.id):
+        raise serializers.ValidationError("Image is invalid")
+    return value
+
+
 #  Product Brand Serializers
 
 class CreateProductBrandSerializer(serializers.ModelSerializer):
@@ -12,11 +19,7 @@ class CreateProductBrandSerializer(serializers.ModelSerializer):
         fields = ["name", "description" , "image"]
 
     def validate_image(self, value):
-        request = self.context.get("request")
-        user = getattr(request, "user", None)
-        if value and value.created_by_id != user.id:
-            raise serializers.ValidationError("Image is invalid")
-        return value
+        return validate_owned_image(value, self.context.get("request"))
 
     def validate(self, attrs):
         request = self.context.get("request")
@@ -33,6 +36,9 @@ class ProductBrandListSerializer(serializers.ModelSerializer):
 
 
 class ProductBrandDetailSerializer(serializers.ModelSerializer):
+    def validate_image(self, value):
+        return validate_owned_image(value, self.context.get("request"))
+
     class Meta:
         model = ProductBrand
         fields = "__all__"
@@ -45,16 +51,15 @@ class CreateProductCategorySerializer(serializers.ModelSerializer):
         model = ProductCategory
         fields = ["name", "slug", "description", "parent", "image"]
 
+    def validate_image(self, value):
+        return validate_owned_image(value, self.context.get("request"))
+
     def validate(self, attrs):
         parent = attrs.get("parent")
         if parent and parent.is_child_node():
             raise serializers.ValidationError("Parent category cannot be a child category")
         
-        image = attrs.get("image")
         request = self.context.get("request")
-        if image and image.created_by_id != request.user.pk:
-            raise serializers.ValidationError({"image": "Image is invalid"})
-
         attrs["created_by"] = request.user
         return attrs
 
@@ -68,6 +73,9 @@ class ProductCategoryListSerializer(serializers.ModelSerializer):
 
 
 class ProductCategoryDetailSerializer(serializers.ModelSerializer):
+    def validate_image(self, value):
+        return validate_owned_image(value, self.context.get("request"))
+
     class Meta:
         model = ProductCategory
         fields = "__all__"


### PR DESCRIPTION
Problem
- Brand and category creation accept image file IDs without verifying that the file belongs to the requesting user.
- Product image and profile image serializers already enforce ownership, so this path was inconsistent.

Fix
- Validate brand and category image ownership before assigning images during creation.

Validation performed
- git diff --check -- augment-store/server/products/serializers.py
- Could not run Django tests because python and python3 are not installed in this environment.

Risk/notes
- Backend-only serializer validation change scoped to augment-store/server/products/serializers.py.