### PR TITLE
fix: invalidate category create caches

### DIFF
--- a/augment-store/server/products/views.py
+++ b/augment-store/server/products/views.py
@@ -20,7 +20,6 @@ from .serializers import (
     CreateProductSerializer, ProductListSerializer, ProductDetailSerializer, SearchQueryListSerializer
 )
 from .filters import ProductFilter, ProductSearchFilter
-from .filters import ProductFilter, ProductSearchFilter
 from .services import ProductCacheService, ProductCategoryCacheService, ProductService, ProductBrandCacheService, SearchService, ProductSearchCacheService, SearchQueryCacheService
 from core.service import CacheInvalidatorMixin, CachedListMixin
 from core.optimization import AutoOptimizeMixin
@@ -128,6 +127,11 @@ class CreateProductCategoryView(CacheInvalidatorMixin, BaseCategoryView, CreateA
     serializer_class = CreateProductCategorySerializer
     permission_classes = [IsAuthenticated, hasAdminOrMerchantRole]
     cache_service_class = ProductCategoryCacheService
+
+    def invalidate_cache(self):
+        super().invalidate_cache()
+        ProductCacheService().clear_namespace()
+        ProductSearchCacheService().clear_namespace()
 
 class ProductCategoryDetailView(CacheInvalidatorMixin, BaseCategoryView, RetrieveUpdateDestroyAPIView):
     serializer_class = ProductCategoryDetailSerializer


### PR DESCRIPTION
Problem
- Product category creation only invalidated the category cache namespace through the default mixin path.
- Related product and search cache namespaces could remain stale after a new category was created.
- products/views.py also had a duplicate ProductFilter/ProductSearchFilter import.

Fix
- Add explicit category-create cache invalidation for related product and product search cache namespaces.
- Remove the duplicate filters import.

Validation performed
- git diff --check -- augment-store/server/products/views.py
- Could not run Django tests because python and python3 are not installed in this environment.

Risk/notes
- Backend-only cache invalidation cleanup scoped to augment-store/server/products/views.py.