### PR TITLE
fix: invalidate merchant order cache

### DIFF
--- a/augment-store/server/checkout/views.py
+++ b/augment-store/server/checkout/views.py
@@ -193,8 +193,7 @@ class AdminOrderUpdateView(BaseOrderView, RetrieveUpdateAPIView):
         from merchant.views import MerchantOrdersCacheService
 
         super().perform_update(serializer)
-        if serializer.instance.status == Order.OrderStatus.COMPLETED:
-            MerchantOrdersCacheService().clear_namespace()
+        MerchantOrdersCacheService().clear_namespace()
 
     def get_queryset(self):
         # Allow admins to retrieve/update any order

--- a/augment-store/server/checkout/views.py
+++ b/augment-store/server/checkout/views.py
@@ -189,6 +189,13 @@ class AdminOrderUpdateView(BaseOrderView, RetrieveUpdateAPIView):
     serializer_class = AdminOrderUpdateSerializer
     permission_classes = [IsAuthenticated, hasAdminRole]
 
+    def perform_update(self, serializer):
+        from merchant.views import MerchantOrdersCacheService
+
+        super().perform_update(serializer)
+        if serializer.instance.status == Order.OrderStatus.COMPLETED:
+            MerchantOrdersCacheService().clear_namespace()
+
     def get_queryset(self):
         # Allow admins to retrieve/update any order
         return super(BaseOrderView, self).get_queryset()


### PR DESCRIPTION
Problem
- Admin order updates can change order state, but merchant order list responses are cached in a separate merchant_orders namespace.
- Without clearing that namespace, merchant dashboards can show stale order data after admin changes.

Fix
- Clear the merchant order cache namespace from the admin order update path.

Validation performed
- git diff --check -- augment-store/server/checkout/views.py
- Could not run Django tests because python and python3 are not installed in this environment.

Risk/notes
- Backend-only cache invalidation change scoped to augment-store/server/checkout/views.py.