### PR TITLE
fix: optimize notification ID validation

### DIFF
--- a/augment-store/server/notifications/serializers.py
+++ b/augment-store/server/notifications/serializers.py
@@ -36,11 +36,13 @@ class MarkAsReadSerializer(serializers.Serializer):
     def validate_notification_ids(self, value):
         user = self.context.get("request").user
         notifications = Notification.objects.get_user_notifications(user).filter(id__in=value)
+        found_ids = {str(notification_id) for notification_id in notifications.values_list("id", flat=True)}
         
-        invalid_ids = []
-        for id in value:
-            if not notifications.filter(id=id).exists():
-                invalid_ids.append(id)
+        invalid_ids = [
+            notification_id
+            for notification_id in value
+            if notification_id not in found_ids
+        ]
         
         if len(invalid_ids):
             raise serializers.ValidationError(f"Notification {invalid_ids} does not exist")
@@ -78,4 +80,3 @@ class MarkAsReadSerializer(serializers.Serializer):
             "count": count,
             "notifications": self.TempSerializer(notifications, many=True).data
         }
-

--- a/augment-store/server/notifications/serializers.py
+++ b/augment-store/server/notifications/serializers.py
@@ -36,7 +36,7 @@ class MarkAsReadSerializer(serializers.Serializer):
     def validate_notification_ids(self, value):
         user = self.context.get("request").user
         notifications = Notification.objects.get_user_notifications(user).filter(id__in=value)
-        found_ids = {str(notification_id) for notification_id in notifications.values_list("id", flat=True)}
+        found_ids = set(notifications.values_list("id", flat=True))
         
         invalid_ids = [
             notification_id


### PR DESCRIPTION
Problem
- Mark-as-read notification ID validation checked each requested ID with a separate exists query.
- This created avoidable repeated database work when multiple notification IDs were submitted.

Fix
- Fetch the matching notification IDs once and compare them against the requested IDs in memory.

Validation performed
- git diff --check -- augment-store/server/notifications/serializers.py
- Could not run Django tests because python and python3 are not installed in this environment.

Risk/notes
- Backend-only serializer validation change scoped to augment-store/server/notifications/serializers.py.