### PR TITLE
fix: normalize shipping amounts to decimal

### DIFF
--- a/augment-store/server/carts/models.py
+++ b/augment-store/server/carts/models.py
@@ -80,7 +80,7 @@ class Cart(BaseModel):
     @property
     def shipping(self):
         # TODO: I will get the shipping cost from the shipping service later (this unblock frontend for now)
-        return 10 if self.subtotal < 50 else 0
+        return Decimal("10.00") if self.subtotal <= 50 else Decimal("0.00")
 
     @property
     def total(self):

--- a/augment-store/server/carts/models.py
+++ b/augment-store/server/carts/models.py
@@ -80,7 +80,7 @@ class Cart(BaseModel):
     @property
     def shipping(self):
         # TODO: I will get the shipping cost from the shipping service later (this unblock frontend for now)
-        return Decimal("10.00") if self.subtotal <= 50 else Decimal("0.00")
+        return Decimal("10.00") if self.subtotal < 50 else Decimal("0.00")
 
     @property
     def total(self):

--- a/augment-store/server/checkout/models.py
+++ b/augment-store/server/checkout/models.py
@@ -76,7 +76,7 @@ class Order(BaseModel):
     @property
     def shipping(self):
         # TODO: I will get the shipping cost from the shipping service later (this unblock frontend for now)
-        return 10 if self.subtotal < 50 else 0
+        return Decimal("10.00") if self.subtotal <= 50 else Decimal("0.00")
 
     @property
     def total(self):

--- a/augment-store/server/checkout/models.py
+++ b/augment-store/server/checkout/models.py
@@ -76,7 +76,7 @@ class Order(BaseModel):
     @property
     def shipping(self):
         # TODO: I will get the shipping cost from the shipping service later (this unblock frontend for now)
-        return Decimal("10.00") if self.subtotal <= 50 else Decimal("0.00")
+        return Decimal("10.00") if self.subtotal < 50 else Decimal("0.00")
 
     @property
     def total(self):


### PR DESCRIPTION
Problem
- Cart and order shipping properties returned integer values while subtotal, tax, and total use Decimal arithmetic.
- This made monetary fields less consistent and more fragile for future serialization or arithmetic changes.

Fix
- Return Decimal shipping amounts from cart and order models.

Validation performed
- git diff --check -- augment-store/server/carts/models.py augment-store/server/checkout/models.py
- Could not run Django tests because python and python3 are not installed in this environment.

Risk/notes
- Backend-only model property cleanup scoped to shipping amount calculation.