### PR TITLE
fix: make admin ticket auth explicit

### DIFF
--- a/augment-store/server/ticket/views.py
+++ b/augment-store/server/ticket/views.py
@@ -76,7 +76,7 @@ class UserTicketsView(TicketBaseView, ListAPIView):
 
 class AdminTicketsView(TicketBaseView, ListAPIView):
     serializer_class = TicketListSerializer
-    permission_classes = [hasAdminRole]
+    permission_classes = [IsAuthenticated, hasAdminRole]
 
     def get_queryset(self):
         queryset = super().get_queryset().annotate(


### PR DESCRIPTION
Problem
- AdminTicketsView only listed hasAdminRole in permission_classes, while other admin views explicitly require both IsAuthenticated and hasAdminRole.
- This made the admin ticket endpoint inconsistent with the rest of the backend permission style.

Fix
- Add IsAuthenticated to AdminTicketsView.permission_classes.

Validation performed
- git diff --check -- augment-store/server/ticket/views.py
- Could not run Django tests because python and python3 are not installed in this environment.

Risk/notes
- Backend-only permission declaration cleanup scoped to augment-store/server/ticket/views.py.