### PR TITLE
fix: reuse wishlist product ID validation

### DIFF
--- a/augment-store/server/carts/serializers.py
+++ b/augment-store/server/carts/serializers.py
@@ -7,9 +7,10 @@ from products.serializers import ProductListSerializer
 
 
 def validate_existing_product_ids(value):
-    existing_ids = set(Product.objects.filter(id__in=value).values_list('id', flat=True))
-    if len(existing_ids) != len(value):
-        missing_ids = [product_id for product_id in value if product_id not in existing_ids]
+    requested_ids = set(value)
+    existing_ids = set(Product.objects.filter(id__in=requested_ids).values_list('id', flat=True))
+    if existing_ids != requested_ids:
+        missing_ids = [product_id for product_id in requested_ids if product_id not in existing_ids]
         raise serializers.ValidationError(f"Product {missing_ids} does not exist")
     return value
 

--- a/augment-store/server/carts/serializers.py
+++ b/augment-store/server/carts/serializers.py
@@ -6,6 +6,14 @@ from products.models import Product
 from products.serializers import ProductListSerializer
 
 
+def validate_existing_product_ids(value):
+    existing_ids = set(Product.objects.filter(id__in=value).values_list('id', flat=True))
+    if len(existing_ids) != len(value):
+        missing_ids = [product_id for product_id in value if product_id not in existing_ids]
+        raise serializers.ValidationError(f"Product {missing_ids} does not exist")
+    return value
+
+
 class AddToCartSerializer(serializers.Serializer):
     product_id = serializers.UUIDField(write_only=True)
     quantity = serializers.IntegerField(min_value=1, write_only=True)
@@ -132,11 +140,7 @@ class AddToWishlistSerializer(serializers.ModelSerializer):
         fields = ["product_ids","products", "created_at", "updated_at"]
 
     def validate_product_ids(self, value):
-        existing_ids = set(Product.objects.filter(id__in=value).values_list('id', flat=True))
-        for product_id in value:
-            if product_id not in existing_ids:
-                raise serializers.ValidationError(f"Product {product_id} does not exist")
-        return value
+        return validate_existing_product_ids(value)
 
     
     def create(self, validated_data):
@@ -154,11 +158,7 @@ class RemoveFromWishlistSerializer(serializers.Serializer):
     product_ids = serializers.ListField(child=serializers.UUIDField())
 
     def validate_product_ids(self, value):
-        existing_ids = set(Product.objects.filter(id__in=value).values_list('id', flat=True))
-        for product_id in value:
-            if product_id not in existing_ids:
-                raise serializers.ValidationError(f"Product {product_id} does not exist")
-        return value
+        return validate_existing_product_ids(value)
 
 
     

--- a/augment-store/server/carts/serializers.py
+++ b/augment-store/server/carts/serializers.py
@@ -9,9 +9,9 @@ from products.serializers import ProductListSerializer
 def validate_existing_product_ids(value):
     requested_ids = set(value)
     existing_ids = set(Product.objects.filter(id__in=requested_ids).values_list('id', flat=True))
-    if existing_ids != requested_ids:
-        missing_ids = [product_id for product_id in requested_ids if product_id not in existing_ids]
-        raise serializers.ValidationError(f"Product {missing_ids} does not exist")
+    for product_id in value:
+        if product_id not in existing_ids:
+            raise serializers.ValidationError(f"Product {product_id} does not exist")
     return value
 
 


### PR DESCRIPTION
Problem
- Add/remove wishlist serializers duplicated product ID validation logic.
- Keeping two copies makes future validation fixes easier to miss.

Fix
- Extract shared product ID existence validation and reuse it from both wishlist serializers.

Validation performed
- git diff --check -- augment-store/server/carts/serializers.py
- Could not run Django tests because python and python3 are not installed in this environment.

Risk/notes
- Backend-only serializer validation cleanup scoped to augment-store/server/carts/serializers.py.