### PR TITLE
fix: restrict new returning analytics

### DIFF
--- a/augment-store/server/dashboard/views.py
+++ b/augment-store/server/dashboard/views.py
@@ -1207,7 +1207,7 @@ class ProductStatisticsViewSet(viewsets.ReadOnlyModelViewSet):
         })
 
 
-    @action(detail=False, methods=['get'], permission_classes=[IsAuthenticated, hasAdminRole])
+    @action(detail=False, methods=['get'], permission_classes=[IsAuthenticated, hasAdminOrMerchantRole])
     def new_vs_returning(self, request):
         """
         Compare new vs returning customer metrics.

--- a/augment-store/server/dashboard/views.py
+++ b/augment-store/server/dashboard/views.py
@@ -1207,7 +1207,7 @@ class ProductStatisticsViewSet(viewsets.ReadOnlyModelViewSet):
         })
 
 
-    @action(detail=False, methods=['get'])
+    @action(detail=False, methods=['get'], permission_classes=[IsAuthenticated, hasAdminRole])
     def new_vs_returning(self, request):
         """
         Compare new vs returning customer metrics.
@@ -1371,4 +1371,3 @@ class AdminAnalyticsView(GenericAPIView):
                 } for p in top_products
             ]
         })
-


### PR DESCRIPTION
Problem
- The new_vs_returning dashboard analytics action exposes customer order and revenue segmentation but only inherits the broad authenticated permission from the viewset.

Fix
- Add an explicit role permission on the action so access is constrained like the other customer analytics endpoints.

Validation performed
- git diff --check -- augment-store/server/dashboard/views.py passed.
- python manage.py test dashboard could not run because python is not installed in this environment.
- python3 manage.py test dashboard could not run because python3 is not installed in this environment.

Risk/notes
- Scope is limited to the dashboard analytics action permission decorator.