### PR TITLE
feat(orderService): add the get admin shipping address endpoint

### DIFF
--- a/augment-store/client/src/config/api.ts
+++ b/augment-store/client/src/config/api.ts
@@ -64,6 +64,7 @@ export const API_ENDPOINTS = {
     DETAIL: (id: string) => `/checkout/orders/${id}/`,
     CREATE: '/checkout/orders/create/',
     CANCEL: (id: string) => `/checkout/orders/${id}/cancel/`,
+    ADMIN_SHIPPING_ADDRESSES: '/checkout/admin/shipping-addresses/',
   },
 
   // User endpoints

--- a/augment-store/client/src/features/orders/types/index.ts
+++ b/augment-store/client/src/features/orders/types/index.ts
@@ -185,3 +185,55 @@ export interface CreateOrderResponse {
     phone: string
   }
 }
+
+// Admin Shipping Address type matching backend ShippingAddressListSerializer (snake_case)
+// Used by GET /api/v1/checkout/admin/shipping-addresses/
+// Backend serializer uses fields = "__all__" so includes all model fields from ShippingAddress model
+export interface AdminShippingAddressAPI {
+  id: string
+  user: string // UUID of the user who owns this address
+  first_name: string
+  last_name: string
+  address_line_1: string
+  address_line_2: string | null
+  city: string
+  state: string
+  postal_code: string
+  country: string
+  created_at: string
+  updated_at: string
+  is_deleted: boolean
+}
+
+// Frontend admin shipping address type (camelCase)
+export interface AdminShippingAddress {
+  id: string
+  user: string
+  firstName: string
+  lastName: string
+  addressLine1: string
+  addressLine2: string | null
+  city: string
+  state: string
+  postalCode: string
+  country: string
+  createdAt: string
+  updatedAt: string
+  isDeleted: boolean
+}
+
+// Paginated admin shipping addresses response from backend (DRF ListAPIView)
+export interface AdminShippingAddressesListResponseAPI {
+  count: number
+  next: string | null
+  previous: string | null
+  results: AdminShippingAddressAPI[]
+}
+
+// Frontend admin shipping addresses list response
+export interface AdminShippingAddressesListResponse {
+  shippingAddresses: AdminShippingAddress[]
+  count: number
+  next: string | null
+  previous: string | null
+}

--- a/augment-store/client/src/services/api/index.ts
+++ b/augment-store/client/src/services/api/index.ts
@@ -42,4 +42,10 @@ export type {
   AdminPaymentsListResponse,
   AdminPaymentsListResponseAPI,
 } from '@features/payment/types'
+export type {
+  AdminShippingAddress,
+  AdminShippingAddressAPI,
+  AdminShippingAddressesListResponse,
+  AdminShippingAddressesListResponseAPI,
+} from '@features/orders/types'
 export { apiClient } from './client'

--- a/augment-store/client/src/services/api/orders/orderService.ts
+++ b/augment-store/client/src/services/api/orders/orderService.ts
@@ -1,6 +1,19 @@
 import { apiClient } from '../client'
 import { API_ENDPOINTS } from '@config/api'
-import type { Order, OrderItem, CreateOrderRequest, OrderListResponse, CreateOrderResponse, OrderListAPIResponse, UpdateAdminOrderRequest, AdminOrderUpdateAPI } from '@features/orders/types'
+import type {
+  Order,
+  OrderItem,
+  CreateOrderRequest,
+  OrderListResponse,
+  CreateOrderResponse,
+  OrderListAPIResponse,
+  UpdateAdminOrderRequest,
+  AdminOrderUpdateAPI,
+  AdminShippingAddressesListResponse,
+  AdminShippingAddressesListResponseAPI,
+  AdminShippingAddressAPI,
+  AdminShippingAddress,
+} from '@features/orders/types'
 
 export const orderService = {
   getOrders: async (page = 1): Promise<OrderListResponse> => {
@@ -307,4 +320,60 @@ export const orderService = {
   updateAdminOrder: async (id: string, data: UpdateAdminOrderRequest): Promise<AdminOrderUpdateAPI> => {
     return apiClient.patch<AdminOrderUpdateAPI>(API_ENDPOINTS.ORDERS.ADMIN_DETAIL(id), data)
   },
+
+  /**
+   * Get paginated list of all shipping addresses (admin only)
+   * Backend uses DRF PageNumberPagination with fixed PAGE_SIZE of 100 (configured in settings.py)
+   *
+   * Related backend code:
+   * - View: augment-store/server/checkout/views.py - AdminShippingAddressListView
+   * - Serializer: augment-store/server/checkout/serializers.py - ShippingAddressListSerializer
+   *
+   * @param page - Page number to fetch (1-based, defaults to 1)
+   * @param signal - Optional AbortSignal for request cancellation
+   * @returns Promise with list of shipping addresses, total count, and pagination URLs
+   */
+  getAdminShippingAddresses: async (page = 1, signal?: AbortSignal): Promise<AdminShippingAddressesListResponse> => {
+    // Validate and normalize page parameter to ensure valid 1-based page number
+    // This prevents invalid values (0, negatives, non-integers, Infinity) from causing backend errors
+    const pageNum = Number(page)
+    const normalizedPage = Number.isFinite(pageNum) ? Math.max(1, Math.floor(pageNum)) : 1
+
+    const response = await apiClient.get<AdminShippingAddressesListResponseAPI>(
+      API_ENDPOINTS.ORDERS.ADMIN_SHIPPING_ADDRESSES,
+      {
+        params: { page: normalizedPage },
+        signal,
+      }
+    )
+
+    // Transform backend response to frontend format
+    return {
+      shippingAddresses: response.results.map(transformAdminShippingAddress),
+      count: response.count,
+      next: response.next,
+      previous: response.previous,
+    }
+  },
+}
+
+/**
+ * Transform backend admin shipping address (snake_case) to frontend format (camelCase)
+ */
+function transformAdminShippingAddress(address: AdminShippingAddressAPI): AdminShippingAddress {
+  return {
+    id: address.id,
+    user: address.user,
+    firstName: address.first_name,
+    lastName: address.last_name,
+    addressLine1: address.address_line_1,
+    addressLine2: address.address_line_2,
+    city: address.city,
+    state: address.state,
+    postalCode: address.postal_code,
+    country: address.country,
+    createdAt: address.created_at,
+    updatedAt: address.updated_at,
+    isDeleted: address.is_deleted,
+  }
 }


### PR DESCRIPTION
## Summary

This PR add the get admin shipping address endpoint

## Changes Made

### Service
- **orderService** - add the get admin shipping address endpoint

## How It Works

## Testing

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author