### PR TITLE
feat(orderStore): add the get admin shipping address action

### DIFF
--- a/augment-store/client/src/store/orderStore.ts
+++ b/augment-store/client/src/store/orderStore.ts
@@ -443,7 +443,8 @@ export const useOrderStore = create<OrderState>()(
 
         // Only clamp the lower bound to prevent page <= 0
         // Don't clamp the upper bound here because totalAdminShippingAddressesPages might not be accurate yet
-        // (it's initialized to 1 and not persisted). The 404 retry logic would be handled by the caller.
+        // (it's initialized to 1 and not persisted). The 404 retry logic below will
+        // handle truly out-of-range pages, allowing deep-links to valid higher pages.
         const validPage = Math.max(1, page)
 
         try {
@@ -486,6 +487,50 @@ export const useOrderStore = create<OrderState>()(
             if (isAbortError(error)) {
               // Request was intentionally cancelled, don't set error state
               throw error
+            }
+
+            // Check if this is a 404 error, which likely means the requested page is out of range
+            // This can happen when total pages shrink (e.g., items deleted) and the current page
+            // becomes invalid. DRF PageNumberPagination returns 404 for out-of-range pages.
+            const axiosError = error as { response?: { status?: number } }
+            const is404Error = axiosError?.response?.status === 404
+
+            if (is404Error && validPage > 1) {
+              // Page is out of range - reset to page 1 and retry to get fresh data
+              console.log(`Page ${validPage} returned 404, retrying with page 1`)
+              try {
+                const retryResponse = await orderService.getAdminShippingAddresses(1, signal)
+
+                // Only update state if this is still the latest request
+                if (requestId === fetchAdminShippingAddressesRequestCounter) {
+                  // Backend uses DRF PageNumberPagination with fixed PAGE_SIZE of 100 (configured in settings.py)
+                  const backendPageSize = 100 // Fixed in backend REST_FRAMEWORK settings
+                  // Normalize response.count to a finite non-negative number to prevent NaN in totalPages
+                  const normalizedCount = Number.isFinite(retryResponse.count) && retryResponse.count >= 0 ? retryResponse.count : 0
+                  const totalPages = Math.max(1, Math.ceil(normalizedCount / backendPageSize))
+
+                  set({
+                    adminShippingAddresses: retryResponse.shippingAddresses,
+                    totalAdminShippingAddresses: normalizedCount,
+                    adminShippingAddressesNext: retryResponse.next,
+                    adminShippingAddressesPrevious: retryResponse.previous,
+                    currentAdminShippingAddressesPage: 1,
+                    totalAdminShippingAddressesPages: totalPages,
+                    isFetchingAdminShippingAddresses: false,
+                    fetchAdminShippingAddressesError: null,
+                  })
+                }
+                return retryResponse
+              } catch (retryError) {
+                // If retry also fails, fall through to normal error handling
+                // Don't log abort errors - these are expected when requests are intentionally cancelled
+                if (!isAbortError(retryError)) {
+                  console.error('Retry with page 1 also failed:', sanitizeErrorForLogging(retryError))
+                } else {
+                  // Retry was also cancelled, don't set error state
+                  throw retryError
+                }
+              }
             }
 
             const errorMessage = 'Failed to fetch admin shipping addresses. Please try again.'

--- a/augment-store/client/src/store/orderStore.ts
+++ b/augment-store/client/src/store/orderStore.ts
@@ -441,11 +441,12 @@ export const useOrderStore = create<OrderState>()(
         fetchAdminShippingAddressesRequestCounter += 1
         const requestId = fetchAdminShippingAddressesRequestCounter
 
-        // Only clamp the lower bound to prevent page <= 0
-        // Don't clamp the upper bound here because totalAdminShippingAddressesPages might not be accurate yet
+        // Normalize page to a finite integer, then clamp to >= 1
+        // This handles NaN, Infinity, -Infinity, and non-integer values
+        // Only clamp the lower bound here because totalAdminShippingAddressesPages might not be accurate yet
         // (it's initialized to 1 and not persisted). The 404 retry logic below will
         // handle truly out-of-range pages, allowing deep-links to valid higher pages.
-        const validPage = Math.max(1, page)
+        const validPage = Math.max(1, Number.isFinite(page) ? Math.floor(page) : 1)
 
         try {
           set({ isFetchingAdminShippingAddresses: true, fetchAdminShippingAddressesError: null })

--- a/augment-store/client/src/store/orderStore.ts
+++ b/augment-store/client/src/store/orderStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand'
 import { persist } from 'zustand/middleware'
-import type { Order, CreateOrderRequest, CreateOrderResponse, OrderListResponse } from '@features/orders/types'
+import type { Order, CreateOrderRequest, CreateOrderResponse, OrderListResponse, AdminShippingAddress, AdminShippingAddressesListResponse } from '@features/orders/types'
 import { isAbortError, sanitizeErrorForLogging } from '@utils/errorUtils'
 
 // Request counter to track the latest fetch request
@@ -12,6 +12,9 @@ let fetchMerchantRequestCounter = 0
 
 // Request counter for admin orders to prevent race conditions
 let fetchAdminRequestCounter = 0
+
+// Request counter for admin shipping addresses to prevent race conditions
+let fetchAdminShippingAddressesRequestCounter = 0
 
 interface OrderState {
   // Current order (most recently created)
@@ -35,6 +38,14 @@ interface OrderState {
   currentAdminPage: number
   totalAdminPages: number
 
+  // Admin shipping addresses list
+  adminShippingAddresses: AdminShippingAddress[]
+  totalAdminShippingAddresses: number
+  adminShippingAddressesNext: string | null
+  adminShippingAddressesPrevious: string | null
+  currentAdminShippingAddressesPage: number
+  totalAdminShippingAddressesPages: number
+
   // Single order detail
   selectedOrder: Order | null
   isFetchingOrder: boolean
@@ -45,6 +56,7 @@ interface OrderState {
   isFetchingOrders: boolean
   isFetchingMerchantOrders: boolean
   isFetchingAdminOrders: boolean
+  isFetchingAdminShippingAddresses: boolean
   isCancelingOrder: boolean
 
   // Error states
@@ -52,6 +64,7 @@ interface OrderState {
   fetchOrdersError: string | null
   fetchMerchantOrdersError: string | null
   fetchAdminOrdersError: string | null
+  fetchAdminShippingAddressesError: string | null
   cancelOrderError: string | null
 
   // Actions
@@ -62,6 +75,7 @@ interface OrderState {
   getAllOrders: (page?: number) => Promise<OrderListResponse>
   getMerchantOrders: (page?: number, signal?: AbortSignal) => Promise<OrderListResponse>
   getAdminOrders: (page?: number, signal?: AbortSignal) => Promise<OrderListResponse>
+  getAdminShippingAddresses: (page?: number, signal?: AbortSignal) => Promise<AdminShippingAddressesListResponse>
   getOrderById: (id: string) => Promise<Order>
   getAdminOrderById: (id: string) => Promise<Order | null>
   setSelectedOrder: (order: Order | null) => void
@@ -69,10 +83,12 @@ interface OrderState {
   clearOrders: () => void
   clearMerchantOrders: () => void
   clearAdminOrders: () => void
+  clearAdminShippingAddresses: () => void
   cancelOrder: (id: string) => Promise<Order>
   setPage: (page: number) => void
   setMerchantPage: (page: number) => void
   setAdminPage: (page: number) => void
+  setAdminShippingAddressesPage: (page: number, signal?: AbortSignal) => void
 }
 
 // Request counter to prevent race conditions in getOrderById and getAdminOrderById
@@ -99,6 +115,12 @@ export const useOrderStore = create<OrderState>()(
       totalAdminOrders: 0,
       currentAdminPage: 1,
       totalAdminPages: 1,
+      adminShippingAddresses: [],
+      totalAdminShippingAddresses: 0,
+      adminShippingAddressesNext: null,
+      adminShippingAddressesPrevious: null,
+      currentAdminShippingAddressesPage: 1,
+      totalAdminShippingAddressesPages: 1,
       selectedOrder: null,
       isFetchingOrder: false,
       fetchOrderError: null,
@@ -106,11 +128,13 @@ export const useOrderStore = create<OrderState>()(
       isFetchingOrders: false,
       isFetchingMerchantOrders: false,
       isFetchingAdminOrders: false,
+      isFetchingAdminShippingAddresses: false,
       isCancelingOrder: false,
       createOrderError: null,
       fetchOrdersError: null,
       fetchMerchantOrdersError: null,
       fetchAdminOrdersError: null,
+      fetchAdminShippingAddressesError: null,
       cancelOrderError: null,
 
       // Actions
@@ -409,6 +433,73 @@ export const useOrderStore = create<OrderState>()(
         }
       },
 
+      getAdminShippingAddresses: async (page = 1, signal?: AbortSignal) => {
+        // Import orderService dynamically to avoid circular dependency
+        const { orderService } = await import('@services/api/orders/orderService')
+
+        // Increment counter and capture the current request ID
+        fetchAdminShippingAddressesRequestCounter += 1
+        const requestId = fetchAdminShippingAddressesRequestCounter
+
+        // Only clamp the lower bound to prevent page <= 0
+        // Don't clamp the upper bound here because totalAdminShippingAddressesPages might not be accurate yet
+        // (it's initialized to 1 and not persisted). The 404 retry logic would be handled by the caller.
+        const validPage = Math.max(1, page)
+
+        try {
+          set({ isFetchingAdminShippingAddresses: true, fetchAdminShippingAddressesError: null })
+          // Note: Backend has fixed page size of 100
+          const response = await orderService.getAdminShippingAddresses(validPage, signal)
+
+          // Only update state if this is still the latest request
+          // This prevents older responses from overwriting newer state
+          if (requestId !== fetchAdminShippingAddressesRequestCounter) {
+            return response
+          }
+
+          // Backend uses DRF PageNumberPagination with fixed PAGE_SIZE of 100 (configured in settings.py)
+          const backendPageSize = 100 // Fixed in backend REST_FRAMEWORK settings
+          // Normalize response.count to a finite non-negative number to prevent NaN in totalPages
+          const normalizedCount = Number.isFinite(response.count) && response.count >= 0 ? response.count : 0
+          const totalPages = Math.max(1, Math.ceil(normalizedCount / backendPageSize))
+
+          // Update state with fetched admin shipping addresses
+          set({
+            adminShippingAddresses: response.shippingAddresses,
+            totalAdminShippingAddresses: normalizedCount,
+            adminShippingAddressesNext: response.next,
+            adminShippingAddressesPrevious: response.previous,
+            currentAdminShippingAddressesPage: validPage,
+            totalAdminShippingAddressesPages: totalPages,
+          })
+
+          return response
+        } catch (error) {
+          // Don't log abort errors - these are expected when requests are intentionally cancelled
+          if (!isAbortError(error)) {
+            console.error('Failed to fetch admin shipping addresses:', sanitizeErrorForLogging(error))
+          }
+
+          // Only update error state if this is still the latest request
+          if (requestId === fetchAdminShippingAddressesRequestCounter) {
+            // Don't treat intentional cancellations as fetch errors
+            if (isAbortError(error)) {
+              // Request was intentionally cancelled, don't set error state
+              throw error
+            }
+
+            const errorMessage = 'Failed to fetch admin shipping addresses. Please try again.'
+            set({ fetchAdminShippingAddressesError: errorMessage })
+          }
+          throw error
+        } finally {
+          // Only update loading state if this is still the latest request
+          if (requestId === fetchAdminShippingAddressesRequestCounter) {
+            set({ isFetchingAdminShippingAddresses: false })
+          }
+        }
+      },
+
       getOrderById: async (id: string) => {
         // Increment counter to track this request
         // This prevents race conditions when multiple calls are made rapidly
@@ -595,6 +686,22 @@ export const useOrderStore = create<OrderState>()(
         })
       },
 
+      clearAdminShippingAddresses: () => {
+        // Increment counter to invalidate any in-flight fetch requests
+        // This prevents in-flight responses from repopulating the store after clear
+        fetchAdminShippingAddressesRequestCounter += 1
+        set({
+          adminShippingAddresses: [],
+          totalAdminShippingAddresses: 0,
+          adminShippingAddressesNext: null,
+          adminShippingAddressesPrevious: null,
+          currentAdminShippingAddressesPage: 1,
+          totalAdminShippingAddressesPages: 1,
+          fetchAdminShippingAddressesError: null,
+          isFetchingAdminShippingAddresses: false,
+        })
+      },
+
       setCreateOrderError: (error) => set({ createOrderError: error }),
 
       cancelOrder: async (id: string) => {
@@ -664,6 +771,24 @@ export const useOrderStore = create<OrderState>()(
           // Don't log abort errors - these are expected when requests are intentionally cancelled
           if (!isAbortError(error)) {
             console.error('Error fetching admin orders on page change:', sanitizeErrorForLogging(error))
+          }
+        })
+      },
+
+      setAdminShippingAddressesPage: (page: number, signal?: AbortSignal) => {
+        // Validate page before setting it optimistically to prevent invalid pagination state
+        // Clamp page to valid range to match the validation in getAdminShippingAddresses
+        const currentTotalPages = get().totalAdminShippingAddressesPages
+        const validPage = Math.max(1, currentTotalPages > 0 ? Math.min(page, currentTotalPages) : page)
+
+        // Update currentAdminShippingAddressesPage optimistically so UI state remains consistent even if fetch fails
+        // This ensures retry logic and pagination controls use the intended page
+        set({ currentAdminShippingAddressesPage: validPage })
+        get().getAdminShippingAddresses(validPage, signal).catch((error) => {
+          // Error is already handled in getAdminShippingAddresses, just prevent unhandled rejection
+          // Don't log abort errors - these are expected when requests are intentionally cancelled
+          if (!isAbortError(error)) {
+            console.error('Error fetching admin shipping addresses on page change:', sanitizeErrorForLogging(error))
           }
         })
       },

--- a/augment-store/client/src/store/orderStore.ts
+++ b/augment-store/client/src/store/orderStore.ts
@@ -822,13 +822,17 @@ export const useOrderStore = create<OrderState>()(
       },
 
       setAdminShippingAddressesPage: (page: number, signal?: AbortSignal) => {
+        // Normalize page to a finite integer >= 1 to prevent invalid state from NaN/non-integer values
+        // This matches the normalization logic in getAdminShippingAddresses
+        const validPage = Math.max(1, Number.isFinite(page) ? Math.floor(page) : 1)
+
         // Update currentAdminShippingAddressesPage optimistically so UI state remains consistent even if fetch fails
         // This ensures retry logic and pagination controls use the intended page
         // Don't clamp to totalAdminShippingAddressesPages here because it's initialized to 1 and not persisted,
         // which would force any first-load navigation to page > 1 back to 1 even if valid.
         // getAdminShippingAddresses handles validation and 404 retry logic.
-        set({ currentAdminShippingAddressesPage: page })
-        get().getAdminShippingAddresses(page, signal).catch((error) => {
+        set({ currentAdminShippingAddressesPage: validPage })
+        get().getAdminShippingAddresses(validPage, signal).catch((error) => {
           // Error is already handled in getAdminShippingAddresses, just prevent unhandled rejection
           // Don't log abort errors - these are expected when requests are intentionally cancelled
           if (!isAbortError(error)) {

--- a/augment-store/client/src/store/orderStore.ts
+++ b/augment-store/client/src/store/orderStore.ts
@@ -822,15 +822,13 @@ export const useOrderStore = create<OrderState>()(
       },
 
       setAdminShippingAddressesPage: (page: number, signal?: AbortSignal) => {
-        // Validate page before setting it optimistically to prevent invalid pagination state
-        // Clamp page to valid range to match the validation in getAdminShippingAddresses
-        const currentTotalPages = get().totalAdminShippingAddressesPages
-        const validPage = Math.max(1, currentTotalPages > 0 ? Math.min(page, currentTotalPages) : page)
-
         // Update currentAdminShippingAddressesPage optimistically so UI state remains consistent even if fetch fails
         // This ensures retry logic and pagination controls use the intended page
-        set({ currentAdminShippingAddressesPage: validPage })
-        get().getAdminShippingAddresses(validPage, signal).catch((error) => {
+        // Don't clamp to totalAdminShippingAddressesPages here because it's initialized to 1 and not persisted,
+        // which would force any first-load navigation to page > 1 back to 1 even if valid.
+        // getAdminShippingAddresses handles validation and 404 retry logic.
+        set({ currentAdminShippingAddressesPage: page })
+        get().getAdminShippingAddresses(page, signal).catch((error) => {
           // Error is already handled in getAdminShippingAddresses, just prevent unhandled rejection
           // Don't log abort errors - these are expected when requests are intentionally cancelled
           if (!isAbortError(error)) {


### PR DESCRIPTION
## Summary

This PR adds the get admin shipping address action to the order store, enabling admins to fetch and manage shipping addresses with pagination support.

## Changes Made

### Store
- **orderStore.ts** - Add admin shipping addresses state management
  - Add `AdminShippingAddress` and `AdminShippingAddressesListResponse` types
  - Add state for admin shipping addresses list with pagination
  - Add `getAdminShippingAddresses` action with page parameter and abort signal support
  - Add `setAdminShippingAddressesPage` action for pagination
  - Add `clearAdminShippingAddresses` action for cleanup
  - Add loading and error states for admin shipping addresses
  - Implement race condition prevention with request counter
  - Add 404 retry logic for out-of-range pages

## How It Works

- The `getAdminShippingAddresses` action fetches admin shipping addresses from the backend with pagination
- Uses request counters to prevent race conditions when multiple requests are made
- Handles 404 errors by retrying with page 1 when the requested page is out of range
- Supports AbortSignal for request cancellation
- Backend uses fixed page size of 100 items per page

## Testing

- Test fetching admin shipping addresses with different page numbers
- Test pagination controls (next/previous)
- Test race condition handling by rapidly changing pages
- Test 404 retry logic by navigating to an out-of-range page
- Test abort signal functionality by canceling in-flight requests

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author