### PR TITLE
feat(accountStore): add getAccountProfile action to fetch current user's profile

### DIFF
--- a/augment-store/client/src/services/api/auth/authService.ts
+++ b/augment-store/client/src/services/api/auth/authService.ts
@@ -103,7 +103,7 @@ export const authService = {
       // This ensures users can reliably log out even if the backend endpoint fails
       useAuthStore.getState().logout()
 
-      // Clear wishlist, cart, and contacts to prevent showing previous user's data
+      // Clear wishlist, cart, contacts, and account profile to prevent showing previous user's data
       // Wrapped in try/catch to prevent chunk-load failures from breaking logout
       try {
         const { useWishlistStore } = await import('@store/wishlistStore')
@@ -114,9 +114,12 @@ export const authService = {
 
         const { useContactStore } = await import('@store/contactStore')
         useContactStore.getState().clearContacts()
+
+        const { useAccountStore } = await import('@store/accountStore')
+        useAccountStore.getState().clearAccountProfile()
       } catch (error) {
         // Ignore chunk-load errors - auth state is already cleared
-        console.warn('Failed to clear wishlist/cart/contacts during logout:', error)
+        console.warn('Failed to clear wishlist/cart/contacts/accountProfile during logout:', error)
       }
     }
   },

--- a/augment-store/client/src/services/api/auth/authService.ts
+++ b/augment-store/client/src/services/api/auth/authService.ts
@@ -1,6 +1,7 @@
 import { apiClient } from '../client'
 import { API_ENDPOINTS } from '@config/api'
 import { useAuthStore } from '@store/authStore'
+import { sanitizeErrorForLogging } from '@utils/errorUtils'
 import type {
   LoginRequest,
   LoginResponse,
@@ -97,7 +98,7 @@ export const authService = {
       await apiClient.post(API_ENDPOINTS.AUTH.LOGOUT)
     } catch (error) {
       // Ignore API errors - client-side logout should always succeed
-      console.warn('Logout API call failed, but clearing client auth state:', error)
+      console.warn('Logout API call failed, but clearing client auth state:', sanitizeErrorForLogging(error))
     } finally {
       // Always clear auth state from Zustand store (which automatically syncs to localStorage)
       // This ensures users can reliably log out even if the backend endpoint fails
@@ -109,28 +110,28 @@ export const authService = {
         const { useWishlistStore } = await import('@store/wishlistStore')
         useWishlistStore.getState().clearWishlist()
       } catch (error) {
-        console.warn('Failed to clear wishlist during logout:', error)
+        console.warn('Failed to clear wishlist during logout:', sanitizeErrorForLogging(error))
       }
 
       try {
         const { useCartStore } = await import('@store/cartStore')
         useCartStore.getState().clearCart()
       } catch (error) {
-        console.warn('Failed to clear cart during logout:', error)
+        console.warn('Failed to clear cart during logout:', sanitizeErrorForLogging(error))
       }
 
       try {
         const { useContactStore } = await import('@store/contactStore')
         useContactStore.getState().clearContacts()
       } catch (error) {
-        console.warn('Failed to clear contacts during logout:', error)
+        console.warn('Failed to clear contacts during logout:', sanitizeErrorForLogging(error))
       }
 
       try {
         const { useAccountStore } = await import('@store/accountStore')
         useAccountStore.getState().clearAccountProfile()
       } catch (error) {
-        console.warn('Failed to clear account profile during logout:', error)
+        console.warn('Failed to clear account profile during logout:', sanitizeErrorForLogging(error))
       }
     }
   },

--- a/augment-store/client/src/services/api/auth/authService.ts
+++ b/augment-store/client/src/services/api/auth/authService.ts
@@ -104,22 +104,33 @@ export const authService = {
       useAuthStore.getState().logout()
 
       // Clear wishlist, cart, contacts, and account profile to prevent showing previous user's data
-      // Wrapped in try/catch to prevent chunk-load failures from breaking logout
+      // Each store cleanup is isolated to prevent one failure from blocking others
       try {
         const { useWishlistStore } = await import('@store/wishlistStore')
         useWishlistStore.getState().clearWishlist()
+      } catch (error) {
+        console.warn('Failed to clear wishlist during logout:', error)
+      }
 
+      try {
         const { useCartStore } = await import('@store/cartStore')
         useCartStore.getState().clearCart()
+      } catch (error) {
+        console.warn('Failed to clear cart during logout:', error)
+      }
 
+      try {
         const { useContactStore } = await import('@store/contactStore')
         useContactStore.getState().clearContacts()
+      } catch (error) {
+        console.warn('Failed to clear contacts during logout:', error)
+      }
 
+      try {
         const { useAccountStore } = await import('@store/accountStore')
         useAccountStore.getState().clearAccountProfile()
       } catch (error) {
-        // Ignore chunk-load errors - auth state is already cleared
-        console.warn('Failed to clear wishlist/cart/contacts/accountProfile during logout:', error)
+        console.warn('Failed to clear account profile during logout:', error)
       }
     }
   },

--- a/augment-store/client/src/store/accountStore.ts
+++ b/augment-store/client/src/store/accountStore.ts
@@ -445,3 +445,37 @@ export const useAccountStore = create<AccountState>((set, get) => ({
     })
   },
 }))
+
+// Subscribe to auth state changes and clear account profile when user logs out
+// This prevents retaining the previous user's profile data after logout, addressing
+// security concerns about profile data retention across user sessions in same-session logout/login flows
+import('@store/authStore')
+  .then(({ useAuthStore }) => {
+    let previousAuthState = useAuthStore.getState().isAuthenticated
+
+    const unsubscribe = useAuthStore.subscribe((state) => {
+      const currentAuthState = state.isAuthenticated
+
+      // Detect transition from authenticated to unauthenticated
+      if (previousAuthState === true && currentAuthState === false) {
+        // Log only in development to prevent noisy console output in production
+        if (import.meta.env.DEV) {
+          console.log('🔒 User logged out - clearing account profile from memory')
+        }
+        useAccountStore.getState().clearAccountProfile()
+      }
+
+      previousAuthState = currentAuthState
+    })
+
+    // Clean up subscription on HMR module disposal to prevent memory leaks
+    if (import.meta.hot) {
+      import.meta.hot.dispose(() => {
+        unsubscribe()
+      })
+    }
+  })
+  .catch((error) => {
+    // Log error but don't fail - auth cleanup is a non-critical enhancement
+    console.error('Failed to set up auth state subscription for account profile cleanup:', error)
+  })

--- a/augment-store/client/src/store/accountStore.ts
+++ b/augment-store/client/src/store/accountStore.ts
@@ -1,5 +1,6 @@
 import { create } from 'zustand'
 import type { AdminUser, AdminUserDetail, UpdateAdminUserRequest } from '@features/accounts/types'
+import type { UserProfile } from '@features/user/types'
 import { parseApiError, sanitizeErrorForLogging } from '@utils/errorUtils'
 
 // Request counter to track the latest fetch request
@@ -17,6 +18,10 @@ let currentFetchingUserId: string | null = null
 // Request counter to track the latest update request
 // Prevents stale responses from overwriting newer state when updating users
 let updateRequestCounter = 0
+
+// Request counter to track the latest get account profile request
+// Prevents stale responses from overwriting newer state when fetching account profile
+let getAccountProfileRequestCounter = 0
 
 interface AccountState {
   // Admin users list state
@@ -38,16 +43,24 @@ interface AccountState {
   isUpdating: boolean
   updateError: string | null
 
+  // Account profile state (current logged-in user)
+  accountProfile: UserProfile | null
+  isFetchingProfile: boolean
+  profileError: string | null
+
   // Actions
   setAdminUsers: (users: AdminUser[], count: number, next: string | null, previous: string | null) => void
   fetchAdminUsers: (page?: number) => Promise<void>
   fetchAdminUserById: (id: string) => Promise<void>
   updateAdminUser: (id: string, data: UpdateAdminUserRequest) => Promise<AdminUserDetail | undefined>
+  getAccountProfile: () => Promise<void>
   clearCurrentAdminUser: () => void
+  clearAccountProfile: () => void
   setLoading: (isLoading: boolean) => void
   setError: (error: string | null) => void
   clearError: () => void
   clearUpdateError: () => void
+  clearProfileError: () => void
   clearAdminUsers: () => void
   setPage: (page: number) => void
 }
@@ -67,6 +80,9 @@ export const useAccountStore = create<AccountState>((set, get) => ({
   fetchByIdError: null,
   isUpdating: false,
   updateError: null,
+  accountProfile: null,
+  isFetchingProfile: false,
+  profileError: null,
 
   // Actions
   setAdminUsers: (users, count, next, previous) =>
@@ -300,6 +316,50 @@ export const useAccountStore = create<AccountState>((set, get) => ({
     }
   },
 
+  getAccountProfile: async () => {
+    // Increment counter and capture the current request ID
+    getAccountProfileRequestCounter += 1
+    const requestId = getAccountProfileRequestCounter
+
+    set({ isFetchingProfile: true, profileError: null })
+    try {
+      // Import userService dynamically to avoid circular dependency
+      const { userService } = await import('@services/api/user/userService')
+      const profile = await userService.getProfile()
+
+      // Only update state if this is still the latest request
+      // This prevents older responses from overwriting newer state
+      if (requestId === getAccountProfileRequestCounter) {
+        set({
+          accountProfile: profile,
+          isFetchingProfile: false,
+        })
+      }
+    } catch (error) {
+      // Only update error state if this is still the latest request
+      // This prevents older errors from overwriting newer state
+      if (requestId !== getAccountProfileRequestCounter) {
+        // Request was invalidated - don't touch state as a newer request may be in-flight
+        return
+      }
+
+      // Use parseApiError to extract user-friendly error message from API response
+      // This properly handles Django/DRF error responses including detail, non_field_errors, etc.
+      const errorMessage = parseApiError(error, {
+        defaultMessage: 'Failed to fetch account profile. Please try again.',
+      })
+
+      set({
+        profileError: errorMessage,
+        isFetchingProfile: false,
+      })
+
+      // Log only sanitized error information to avoid leaking sensitive data
+      // (e.g., Authorization headers in Axios config)
+      console.error('Failed to fetch account profile:', sanitizeErrorForLogging(error))
+    }
+  },
+
   setLoading: (isLoading) => set({ isLoading }),
 
   setError: (error) => set({ error }),
@@ -307,6 +367,20 @@ export const useAccountStore = create<AccountState>((set, get) => ({
   clearError: () => set({ error: null }),
 
   clearUpdateError: () => set({ updateError: null }),
+
+  clearProfileError: () => set({ profileError: null }),
+
+  clearAccountProfile: () => {
+    // Increment counter to invalidate any in-flight get account profile requests
+    // This prevents in-flight responses from repopulating the store after clear
+    getAccountProfileRequestCounter += 1
+
+    set({
+      accountProfile: null,
+      isFetchingProfile: false,
+      profileError: null,
+    })
+  },
 
   clearCurrentAdminUser: () => {
     // Increment counters to invalidate any in-flight fetch-by-id and update requests

--- a/augment-store/client/src/store/accountStore.ts
+++ b/augment-store/client/src/store/accountStore.ts
@@ -445,37 +445,3 @@ export const useAccountStore = create<AccountState>((set, get) => ({
     })
   },
 }))
-
-// Subscribe to auth state changes and clear account profile when user logs out
-// This prevents retaining the previous user's profile data after logout, addressing
-// security concerns about profile data retention across user sessions in same-session logout/login flows
-import('@store/authStore')
-  .then(({ useAuthStore }) => {
-    let previousAuthState = useAuthStore.getState().isAuthenticated
-
-    const unsubscribe = useAuthStore.subscribe((state) => {
-      const currentAuthState = state.isAuthenticated
-
-      // Detect transition from authenticated to unauthenticated
-      if (previousAuthState === true && currentAuthState === false) {
-        // Log only in development to prevent noisy console output in production
-        if (import.meta.env.DEV) {
-          console.log('🔒 User logged out - clearing account profile from memory')
-        }
-        useAccountStore.getState().clearAccountProfile()
-      }
-
-      previousAuthState = currentAuthState
-    })
-
-    // Clean up subscription on HMR module disposal to prevent memory leaks
-    if (import.meta.hot) {
-      import.meta.hot.dispose(() => {
-        unsubscribe()
-      })
-    }
-  })
-  .catch((error) => {
-    // Log error but don't fail - auth cleanup is a non-critical enhancement
-    console.error('Failed to set up auth state subscription for account profile cleanup:', sanitizeErrorForLogging(error))
-  })

--- a/augment-store/client/src/store/accountStore.ts
+++ b/augment-store/client/src/store/accountStore.ts
@@ -477,5 +477,5 @@ import('@store/authStore')
   })
   .catch((error) => {
     // Log error but don't fail - auth cleanup is a non-critical enhancement
-    console.error('Failed to set up auth state subscription for account profile cleanup:', error)
+    console.error('Failed to set up auth state subscription for account profile cleanup:', sanitizeErrorForLogging(error))
   })


### PR DESCRIPTION
## Summary

This PR adds the `getAccountProfile` action to the account store, enabling the application to fetch and manage the currently logged-in user's profile information.

## Changes Made

### Store
- **accountStore.ts** - Add account profile state management
  - Add `UserProfile` type import from `@features/user/types`
  - Add state for account profile with loading and error states:
    - `accountProfile: UserProfile | null`
    - `isFetchingProfile: boolean`
    - `profileError: string | null`
  - Add `getAccountProfile` action to fetch the current user's profile
  - Add `clearAccountProfile` action for cleanup
  - Add `clearProfileError` action for error state management
  - Implement race condition prevention with request counter (`getAccountProfileRequestCounter`)

## How It Works

- The `getAccountProfile` action fetches the current logged-in user's profile from the backend
- Uses request counters to prevent race conditions when multiple requests are made
- Properly handles errors with user-friendly messages using `parseApiError`
- Logs sanitized errors to avoid leaking sensitive data

## Testing

- Test fetching account profile
- Test error handling when the API request fails
- Test race condition handling by making multiple rapid requests
- Test cleanup functionality with `clearAccountProfile`

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author