### PR TITLE
feat(notifications): add notification sound preference with audio playback

### DIFF
--- a/augment-store/client/src/features/admin-dashboard/pages/AdminSettingsPage.tsx
+++ b/augment-store/client/src/features/admin-dashboard/pages/AdminSettingsPage.tsx
@@ -47,7 +47,14 @@ const AdminSettingsPage = () => {
   const toast = useToast()
   const { user, isAuthenticated, hasHydrated } = useAuthStore()
   const { mode, toggleMode } = useThemeStore()
-  const { toastDuration, setToastDuration, toastPosition, setToastPosition } = useUIStore()
+  const {
+    toastDuration,
+    setToastDuration,
+    toastPosition,
+    setToastPosition,
+    notificationSoundsEnabled,
+    setNotificationSoundsEnabled
+  } = useUIStore()
 
   // Get current language name - normalize to a supported LanguageCode
   const currentLanguage: LanguageCode =
@@ -229,6 +236,23 @@ const AdminSettingsPage = () => {
       console.error('Failed to change toast position:', error)
       // Show error feedback to user
       toast.error(t('admin.settingsPage.toastPositionChangeFailed'))
+    }
+  }
+
+  const handleNotificationSoundsToggle = () => {
+    try {
+      const newValue = !notificationSoundsEnabled
+      setNotificationSoundsEnabled(newValue)
+      // Show success feedback to user
+      toast.success(
+        newValue
+          ? 'Notification sounds enabled'
+          : 'Notification sounds disabled'
+      )
+    } catch (error) {
+      console.error('Failed to toggle notification sounds:', error)
+      // Show error feedback to user
+      toast.error('Failed to toggle notification sounds. Please try again.')
     }
   }
 
@@ -482,6 +506,44 @@ const AdminSettingsPage = () => {
                 ))}
               </Select>
             </FormControl>
+          </Box>
+
+          {/* Notification Sounds Toggle */}
+          <Box
+            sx={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              p: 2,
+              bgcolor: 'background.default',
+              borderRadius: 2,
+              mt: 2,
+            }}
+          >
+            <Box sx={{ display: 'flex', alignItems: 'center', gap: 2 }}>
+              <NotificationsIcon sx={{ fontSize: 24, color: 'primary.main' }} />
+              <Box>
+                <Typography variant="body1" sx={{ fontWeight: 500 }}>
+                  Notification Sounds
+                </Typography>
+                <Typography variant="body2" color="text.secondary">
+                  {notificationSoundsEnabled
+                    ? 'Notification sounds are currently enabled'
+                    : 'Notification sounds are currently disabled'}
+                </Typography>
+              </Box>
+            </Box>
+            <FormControlLabel
+              control={
+                <Switch
+                  checked={notificationSoundsEnabled}
+                  onChange={handleNotificationSoundsToggle}
+                  color="primary"
+                />
+              }
+              label={notificationSoundsEnabled ? 'Enabled' : 'Disabled'}
+              labelPlacement="start"
+            />
           </Box>
         </Box>
 

--- a/augment-store/client/src/features/admin-dashboard/pages/AdminSettingsPage.tsx
+++ b/augment-store/client/src/features/admin-dashboard/pages/AdminSettingsPage.tsx
@@ -239,9 +239,9 @@ const AdminSettingsPage = () => {
     }
   }
 
-  const handleNotificationSoundsToggle = () => {
+  const handleNotificationSoundsToggle = (event: React.ChangeEvent<HTMLInputElement>) => {
     try {
-      const newValue = !notificationSoundsEnabled
+      const newValue = event.target.checked
       setNotificationSoundsEnabled(newValue)
       // Show success feedback to user
       toast.success(

--- a/augment-store/client/src/features/admin-dashboard/pages/AdminSettingsPage.tsx
+++ b/augment-store/client/src/features/admin-dashboard/pages/AdminSettingsPage.tsx
@@ -246,13 +246,13 @@ const AdminSettingsPage = () => {
       // Show success feedback to user
       toast.success(
         newValue
-          ? 'Notification sounds enabled'
-          : 'Notification sounds disabled'
+          ? t('admin.settingsPage.notificationSoundsEnabledSuccess')
+          : t('admin.settingsPage.notificationSoundsDisabledSuccess')
       )
     } catch (error) {
       console.error('Failed to toggle notification sounds:', error)
       // Show error feedback to user
-      toast.error('Failed to toggle notification sounds. Please try again.')
+      toast.error(t('admin.settingsPage.notificationSoundsToggleFailed'))
     }
   }
 
@@ -524,12 +524,12 @@ const AdminSettingsPage = () => {
               <NotificationsIcon sx={{ fontSize: 24, color: 'primary.main' }} />
               <Box>
                 <Typography variant="body1" sx={{ fontWeight: 500 }}>
-                  Notification Sounds
+                  {t('admin.settingsPage.notificationSounds')}
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
                   {notificationSoundsEnabled
-                    ? 'Notification sounds are currently enabled'
-                    : 'Notification sounds are currently disabled'}
+                    ? t('admin.settingsPage.notificationSoundsEnabled')
+                    : t('admin.settingsPage.notificationSoundsDisabled')}
                 </Typography>
               </Box>
             </Box>
@@ -541,7 +541,7 @@ const AdminSettingsPage = () => {
                   color="primary"
                 />
               }
-              label={notificationSoundsEnabled ? 'Enabled' : 'Disabled'}
+              label={notificationSoundsEnabled ? t('admin.settingsPage.notificationSoundsEnabledLabel') : t('admin.settingsPage.notificationSoundsDisabledLabel')}
               labelPlacement="start"
             />
           </Box>

--- a/augment-store/client/src/features/notifications/components/NotificationBell.tsx
+++ b/augment-store/client/src/features/notifications/components/NotificationBell.tsx
@@ -20,6 +20,8 @@ const NotificationBell = () => {
   // Track previous unread count to detect new notifications
   // Initialize to undefined to prevent sound on initial hydration
   const prevUnreadCountRef = useRef<number | undefined>(undefined)
+  // Track whether initial fetch has completed
+  const hasInitializedRef = useRef(false)
 
   // Fetch unread count when component mounts (only if authenticated)
   useEffect(() => {
@@ -30,19 +32,20 @@ const NotificationBell = () => {
 
   // Play sound when unread count increases (new notifications arrive)
   useEffect(() => {
-    // Only play sound if:
-    // 1. User is authenticated
-    // 2. Previous count is defined (not initial mount)
-    // 3. Current count is greater than previous count (new notification)
-    if (
-      isAuthenticated &&
-      prevUnreadCountRef.current !== undefined &&
-      unreadCount > prevUnreadCountRef.current
-    ) {
+    // Skip initial hydration: wait until first fetch completes
+    if (!hasInitializedRef.current) {
+      // Mark as initialized and store initial count
+      hasInitializedRef.current = true
+      prevUnreadCountRef.current = unreadCount
+      return
+    }
+
+    // Only play sound if count increased (new notifications arrived)
+    if (isAuthenticated && unreadCount > prevUnreadCountRef.current!) {
       playNotificationSoundIfEnabled(notificationSoundsEnabled)
     }
 
-    // Update the previous count reference
+    // Always update the reference for subsequent comparisons
     prevUnreadCountRef.current = unreadCount
   }, [unreadCount, isAuthenticated, notificationSoundsEnabled])
 

--- a/augment-store/client/src/features/notifications/components/NotificationBell.tsx
+++ b/augment-store/client/src/features/notifications/components/NotificationBell.tsx
@@ -32,22 +32,25 @@ const NotificationBell = () => {
 
   // Play sound when unread count increases (new notifications arrive)
   useEffect(() => {
-    // On first render, initialize the ref and mark as initialized
+    // On first render, just mark as initialized without storing the count
+    // This ensures we skip the very first unreadCount value entirely
     if (!hasInitializedRef.current) {
       hasInitializedRef.current = true
+      return
+    }
+
+    // On second render (after initial fetch), store the count but don't play sound
+    // This establishes the baseline for future comparisons
+    if (prevUnreadCountRef.current === undefined) {
       prevUnreadCountRef.current = unreadCount
       return
     }
 
     // Only play sound if:
-    // 1. Previous count exists (this is at least the second update after initialization)
+    // 1. Previous count exists (this is at least the third update - after baseline is set)
     // 2. User is authenticated
     // 3. Count increased (new notifications arrived)
-    if (
-      prevUnreadCountRef.current !== undefined &&
-      isAuthenticated &&
-      unreadCount > prevUnreadCountRef.current
-    ) {
+    if (isAuthenticated && unreadCount > prevUnreadCountRef.current) {
       playNotificationSoundIfEnabled(notificationSoundsEnabled)
     }
 

--- a/augment-store/client/src/features/notifications/components/NotificationBell.tsx
+++ b/augment-store/client/src/features/notifications/components/NotificationBell.tsx
@@ -1,18 +1,24 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import { IconButton, Badge, Tooltip } from '@mui/material'
 import { Notifications as NotificationsIcon } from '@mui/icons-material'
 import { useNotificationStore } from '@store/notificationStore'
 import { useAuthStore } from '@store/authStore'
+import { useUIStore } from '@store/uiStore'
 import { useTranslation } from '@hooks/useTranslation'
 import { POLLING_INTERVAL } from '@constants/index'
+import { playNotificationSoundIfEnabled } from '@utils/soundUtils'
 import NotificationList from './NotificationList'
 
 const NotificationBell = () => {
   const { t } = useTranslation()
   const { isAuthenticated } = useAuthStore()
   const { unreadCount, fetchUnreadCount } = useNotificationStore()
+  const { notificationSoundsEnabled } = useUIStore()
   const [anchorEl, setAnchorEl] = useState<null | HTMLElement>(null)
   const open = Boolean(anchorEl)
+
+  // Track previous unread count to detect new notifications
+  const prevUnreadCountRef = useRef<number>(unreadCount)
 
   // Fetch unread count when component mounts (only if authenticated)
   useEffect(() => {
@@ -20,6 +26,24 @@ const NotificationBell = () => {
       fetchUnreadCount()
     }
   }, [isAuthenticated, fetchUnreadCount])
+
+  // Play sound when unread count increases (new notifications arrive)
+  useEffect(() => {
+    // Only play sound if:
+    // 1. User is authenticated
+    // 2. Previous count is defined (not initial mount)
+    // 3. Current count is greater than previous count (new notification)
+    if (
+      isAuthenticated &&
+      prevUnreadCountRef.current !== undefined &&
+      unreadCount > prevUnreadCountRef.current
+    ) {
+      playNotificationSoundIfEnabled(notificationSoundsEnabled)
+    }
+
+    // Update the previous count reference
+    prevUnreadCountRef.current = unreadCount
+  }, [unreadCount, isAuthenticated, notificationSoundsEnabled])
 
   // Poll for unread count every 30 seconds
   useEffect(() => {

--- a/augment-store/client/src/features/notifications/components/NotificationBell.tsx
+++ b/augment-store/client/src/features/notifications/components/NotificationBell.tsx
@@ -32,9 +32,10 @@ const NotificationBell = () => {
 
   // Play sound when unread count increases (new notifications arrive)
   useEffect(() => {
-    // On first render, just mark as initialized without storing count
+    // On first render, initialize the ref and mark as initialized
     if (!hasInitializedRef.current) {
       hasInitializedRef.current = true
+      prevUnreadCountRef.current = unreadCount
       return
     }
 

--- a/augment-store/client/src/features/notifications/components/NotificationBell.tsx
+++ b/augment-store/client/src/features/notifications/components/NotificationBell.tsx
@@ -32,16 +32,21 @@ const NotificationBell = () => {
 
   // Play sound when unread count increases (new notifications arrive)
   useEffect(() => {
-    // Skip initial hydration: wait until first fetch completes
+    // On first render, just mark as initialized without storing count
     if (!hasInitializedRef.current) {
-      // Mark as initialized and store initial count
       hasInitializedRef.current = true
-      prevUnreadCountRef.current = unreadCount
       return
     }
 
-    // Only play sound if count increased (new notifications arrived)
-    if (isAuthenticated && unreadCount > prevUnreadCountRef.current!) {
+    // Only play sound if:
+    // 1. Previous count exists (this is at least the second update after initialization)
+    // 2. User is authenticated
+    // 3. Count increased (new notifications arrived)
+    if (
+      prevUnreadCountRef.current !== undefined &&
+      isAuthenticated &&
+      unreadCount > prevUnreadCountRef.current
+    ) {
       playNotificationSoundIfEnabled(notificationSoundsEnabled)
     }
 

--- a/augment-store/client/src/features/notifications/components/NotificationBell.tsx
+++ b/augment-store/client/src/features/notifications/components/NotificationBell.tsx
@@ -18,7 +18,8 @@ const NotificationBell = () => {
   const open = Boolean(anchorEl)
 
   // Track previous unread count to detect new notifications
-  const prevUnreadCountRef = useRef<number>(unreadCount)
+  // Initialize to undefined to prevent sound on initial hydration
+  const prevUnreadCountRef = useRef<number | undefined>(undefined)
 
   // Fetch unread count when component mounts (only if authenticated)
   useEffect(() => {

--- a/augment-store/client/src/features/notifications/components/NotificationBell.tsx
+++ b/augment-store/client/src/features/notifications/components/NotificationBell.tsx
@@ -18,10 +18,9 @@ const NotificationBell = () => {
   const open = Boolean(anchorEl)
 
   // Track previous unread count to detect new notifications
-  // Initialize to undefined to prevent sound on initial hydration
   const prevUnreadCountRef = useRef<number | undefined>(undefined)
-  // Track whether initial fetch has completed
-  const hasInitializedRef = useRef(false)
+  // Track the authenticated session to reset baseline on login
+  const prevAuthRef = useRef(isAuthenticated)
 
   // Fetch unread count when component mounts (only if authenticated)
   useEffect(() => {
@@ -32,22 +31,28 @@ const NotificationBell = () => {
 
   // Play sound when unread count increases (new notifications arrive)
   useEffect(() => {
-    // On first render, just mark as initialized without storing the count
-    // This ensures we skip the very first unreadCount value entirely
-    if (!hasInitializedRef.current) {
-      hasInitializedRef.current = true
+    // Reset baseline on login (when isAuthenticated transitions from false to true)
+    if (isAuthenticated && !prevAuthRef.current) {
+      prevAuthRef.current = true
+      prevUnreadCountRef.current = unreadCount
       return
     }
 
-    // On second render (after initial fetch), store the count but don't play sound
-    // This establishes the baseline for future comparisons
+    // Update auth tracking on logout
+    if (!isAuthenticated) {
+      prevAuthRef.current = false
+      prevUnreadCountRef.current = undefined
+      return
+    }
+
+    // Initialize baseline on first run when already authenticated
     if (prevUnreadCountRef.current === undefined) {
       prevUnreadCountRef.current = unreadCount
       return
     }
 
     // Only play sound if:
-    // 1. Previous count exists (this is at least the third update - after baseline is set)
+    // 1. Previous count exists (baseline is established)
     // 2. User is authenticated
     // 3. Count increased (new notifications arrived)
     if (isAuthenticated && unreadCount > prevUnreadCountRef.current) {

--- a/augment-store/client/src/locales/de/translation.json
+++ b/augment-store/client/src/locales/de/translation.json
@@ -1358,6 +1358,14 @@
         "bottom-center": "Unten Mitte",
         "bottom-right": "Unten Rechts"
       },
+      "notificationSounds": "Benachrichtigungstöne",
+      "notificationSoundsEnabled": "Benachrichtigungstöne sind derzeit aktiviert",
+      "notificationSoundsDisabled": "Benachrichtigungstöne sind derzeit deaktiviert",
+      "notificationSoundsEnabledLabel": "Aktiviert",
+      "notificationSoundsDisabledLabel": "Deaktiviert",
+      "notificationSoundsEnabledSuccess": "Benachrichtigungstöne aktiviert",
+      "notificationSoundsDisabledSuccess": "Benachrichtigungstöne deaktiviert",
+      "notificationSoundsToggleFailed": "Benachrichtigungstöne konnten nicht umgeschaltet werden. Bitte versuchen Sie es erneut.",
       "moreSettings": "Weitere Einstellungen Demnächst",
       "moreSettingsDescription": "Zusätzliche Konfigurationsoptionen werden hier in zukünftigen Updates verfügbar sein."
     },

--- a/augment-store/client/src/locales/en/translation.json
+++ b/augment-store/client/src/locales/en/translation.json
@@ -1358,6 +1358,14 @@
         "bottom-center": "Bottom Center",
         "bottom-right": "Bottom Right"
       },
+      "notificationSounds": "Notification Sounds",
+      "notificationSoundsEnabled": "Notification sounds are currently enabled",
+      "notificationSoundsDisabled": "Notification sounds are currently disabled",
+      "notificationSoundsEnabledLabel": "Enabled",
+      "notificationSoundsDisabledLabel": "Disabled",
+      "notificationSoundsEnabledSuccess": "Notification sounds enabled",
+      "notificationSoundsDisabledSuccess": "Notification sounds disabled",
+      "notificationSoundsToggleFailed": "Failed to toggle notification sounds. Please try again.",
       "moreSettings": "More Settings Coming Soon",
       "moreSettingsDescription": "Additional configuration options will be available here in future updates."
     },

--- a/augment-store/client/src/locales/es/translation.json
+++ b/augment-store/client/src/locales/es/translation.json
@@ -1358,6 +1358,14 @@
         "bottom-center": "Inferior Centro",
         "bottom-right": "Inferior Derecha"
       },
+      "notificationSounds": "Sonidos de Notificación",
+      "notificationSoundsEnabled": "Los sonidos de notificación están actualmente habilitados",
+      "notificationSoundsDisabled": "Los sonidos de notificación están actualmente deshabilitados",
+      "notificationSoundsEnabledLabel": "Habilitado",
+      "notificationSoundsDisabledLabel": "Deshabilitado",
+      "notificationSoundsEnabledSuccess": "Sonidos de notificación habilitados",
+      "notificationSoundsDisabledSuccess": "Sonidos de notificación deshabilitados",
+      "notificationSoundsToggleFailed": "Error al cambiar los sonidos de notificación. Por favor, inténtalo de nuevo.",
       "moreSettings": "Más Configuraciones Próximamente",
       "moreSettingsDescription": "Opciones de configuración adicionales estarán disponibles aquí en futuras actualizaciones."
     },

--- a/augment-store/client/src/locales/fr/translation.json
+++ b/augment-store/client/src/locales/fr/translation.json
@@ -1358,6 +1358,14 @@
         "bottom-center": "Bas Centre",
         "bottom-right": "Bas Droite"
       },
+      "notificationSounds": "Sons de Notification",
+      "notificationSoundsEnabled": "Les sons de notification sont actuellement activés",
+      "notificationSoundsDisabled": "Les sons de notification sont actuellement désactivés",
+      "notificationSoundsEnabledLabel": "Activé",
+      "notificationSoundsDisabledLabel": "Désactivé",
+      "notificationSoundsEnabledSuccess": "Sons de notification activés",
+      "notificationSoundsDisabledSuccess": "Sons de notification désactivés",
+      "notificationSoundsToggleFailed": "Échec du basculement des sons de notification. Veuillez réessayer.",
       "moreSettings": "Plus de Paramètres Bientôt",
       "moreSettingsDescription": "Des options de configuration supplémentaires seront disponibles ici dans les futures mises à jour."
     },

--- a/augment-store/client/src/store/uiStore.ts
+++ b/augment-store/client/src/store/uiStore.ts
@@ -50,6 +50,22 @@ const validateToastPosition = (position: unknown): ToastPosition => {
   return DEFAULT_TOAST_POSITION
 }
 
+/**
+ * Validates notification sounds enabled setting to ensure it's a boolean
+ * Prevents non-boolean values from corrupted/edited localStorage
+ * @param enabled - The value to validate
+ * @returns A boolean value, defaults to true if invalid
+ */
+const validateNotificationSoundsEnabled = (enabled: unknown): boolean => {
+  // Check if the value is a valid boolean
+  if (typeof enabled === 'boolean') {
+    return enabled
+  }
+
+  // Default to true for invalid values
+  return true
+}
+
 interface UIState {
   isSidebarOpen: boolean
   isCartDrawerOpen: boolean
@@ -133,7 +149,7 @@ export const useUIStore = create<UIState>()(
 
       setToastPosition: (position) => set({ toastPosition: validateToastPosition(position) }),
 
-      setNotificationSoundsEnabled: (enabled) => set({ notificationSoundsEnabled: enabled }),
+      setNotificationSoundsEnabled: (enabled) => set({ notificationSoundsEnabled: validateNotificationSoundsEnabled(enabled) }),
     }),
     {
       name: 'ui-storage',
@@ -143,13 +159,16 @@ export const useUIStore = create<UIState>()(
         notificationSoundsEnabled: state.notificationSoundsEnabled,
       }),
       onRehydrateStorage: () => (state) => {
-        // Validate and normalize toastDuration and toastPosition after rehydration from storage
+        // Validate and normalize toastDuration, toastPosition, and notificationSoundsEnabled after rehydration from storage
         // Use setter methods to ensure subscribers are notified of the validated values
         if (state?.toastDuration !== undefined) {
           state.setToastDuration(state.toastDuration)
         }
         if (state?.toastPosition !== undefined) {
           state.setToastPosition(state.toastPosition)
+        }
+        if (state?.notificationSoundsEnabled !== undefined) {
+          state.setNotificationSoundsEnabled(state.notificationSoundsEnabled)
         }
       },
     }

--- a/augment-store/client/src/store/uiStore.ts
+++ b/augment-store/client/src/store/uiStore.ts
@@ -54,7 +54,7 @@ const validateToastPosition = (position: unknown): ToastPosition => {
  * Validates notification sounds enabled setting to ensure it's a boolean
  * Prevents non-boolean values from corrupted/edited localStorage
  * @param enabled - The value to validate
- * @returns A boolean value, defaults to true if invalid
+ * @returns A boolean value, defaults to false if invalid (opt-in behavior)
  */
 const validateNotificationSoundsEnabled = (enabled: unknown): boolean => {
   // Check if the value is a valid boolean
@@ -62,8 +62,8 @@ const validateNotificationSoundsEnabled = (enabled: unknown): boolean => {
     return enabled
   }
 
-  // Default to true for invalid values
-  return true
+  // Default to false for invalid values (opt-in behavior)
+  return false
 }
 
 interface UIState {
@@ -107,7 +107,7 @@ export const useUIStore = create<UIState>()(
       isLoading: false,
       toastDuration: DEFAULT_TOAST_DURATION,
       toastPosition: DEFAULT_TOAST_POSITION,
-      notificationSoundsEnabled: true, // Enable notification sounds by default
+      notificationSoundsEnabled: false, // Notification sounds disabled by default (opt-in)
 
       toggleSidebar: () => set((state) => ({ isSidebarOpen: !state.isSidebarOpen })),
 

--- a/augment-store/client/src/store/uiStore.ts
+++ b/augment-store/client/src/store/uiStore.ts
@@ -59,6 +59,7 @@ interface UIState {
   isLoading: boolean
   toastDuration: number // Default toast duration in milliseconds
   toastPosition: ToastPosition // Default toast position
+  notificationSoundsEnabled: boolean // Enable/disable notification sounds
 
   // Actions
   toggleSidebar: () => void
@@ -76,6 +77,7 @@ interface UIState {
   setGlobalLoading: (isLoading: boolean) => void
   setToastDuration: (duration: number) => void
   setToastPosition: (position: ToastPosition) => void
+  setNotificationSoundsEnabled: (enabled: boolean) => void
 }
 
 export const useUIStore = create<UIState>()(
@@ -89,6 +91,7 @@ export const useUIStore = create<UIState>()(
       isLoading: false,
       toastDuration: DEFAULT_TOAST_DURATION,
       toastPosition: DEFAULT_TOAST_POSITION,
+      notificationSoundsEnabled: true, // Enable notification sounds by default
 
       toggleSidebar: () => set((state) => ({ isSidebarOpen: !state.isSidebarOpen })),
 
@@ -129,12 +132,15 @@ export const useUIStore = create<UIState>()(
       setToastDuration: (duration) => set({ toastDuration: validateToastDuration(duration) }),
 
       setToastPosition: (position) => set({ toastPosition: validateToastPosition(position) }),
+
+      setNotificationSoundsEnabled: (enabled) => set({ notificationSoundsEnabled: enabled }),
     }),
     {
       name: 'ui-storage',
       partialize: (state) => ({
         toastDuration: state.toastDuration,
         toastPosition: state.toastPosition,
+        notificationSoundsEnabled: state.notificationSoundsEnabled,
       }),
       onRehydrateStorage: () => (state) => {
         // Validate and normalize toastDuration and toastPosition after rehydration from storage

--- a/augment-store/client/src/utils/soundUtils.ts
+++ b/augment-store/client/src/utils/soundUtils.ts
@@ -1,0 +1,56 @@
+/**
+ * Sound utility functions for playing notification sounds
+ */
+
+/**
+ * Play a notification sound
+ * Uses the Web Audio API to generate a simple notification tone
+ * Gracefully handles errors if audio playback is blocked by browser
+ */
+export const playNotificationSound = (): void => {
+  try {
+    // Create AudioContext
+    const audioContext = new (window.AudioContext || (window as any).webkitAudioContext)()
+    
+    // Create oscillator for the notification sound
+    const oscillator = audioContext.createOscillator()
+    const gainNode = audioContext.createGain()
+    
+    // Connect nodes
+    oscillator.connect(gainNode)
+    gainNode.connect(audioContext.destination)
+    
+    // Configure sound parameters
+    oscillator.type = 'sine' // Smooth sine wave
+    oscillator.frequency.setValueAtTime(800, audioContext.currentTime) // 800 Hz frequency
+    
+    // Create a short beep with fade out
+    gainNode.gain.setValueAtTime(0.3, audioContext.currentTime) // Initial volume
+    gainNode.gain.exponentialRampToValueAtTime(0.01, audioContext.currentTime + 0.2) // Fade out
+    
+    // Start and stop the sound
+    oscillator.start(audioContext.currentTime)
+    oscillator.stop(audioContext.currentTime + 0.2) // 200ms duration
+    
+    // Clean up after sound finishes
+    oscillator.onended = () => {
+      oscillator.disconnect()
+      gainNode.disconnect()
+      audioContext.close()
+    }
+  } catch (error) {
+    // Silently fail if audio playback is not available or blocked
+    // This prevents errors in environments where audio is disabled
+    console.debug('Notification sound could not be played:', error)
+  }
+}
+
+/**
+ * Play a notification sound conditionally based on user preferences
+ * @param enabled - Whether notification sounds are enabled
+ */
+export const playNotificationSoundIfEnabled = (enabled: boolean): void => {
+  if (enabled) {
+    playNotificationSound()
+  }
+}

--- a/augment-store/client/src/utils/soundUtils.ts
+++ b/augment-store/client/src/utils/soundUtils.ts
@@ -36,7 +36,9 @@ export const playNotificationSound = (): void => {
     oscillator.onended = () => {
       oscillator.disconnect()
       gainNode.disconnect()
-      audioContext.close()
+      audioContext.close().catch((error) => {
+        console.debug('Failed to close audio context:', error)
+      })
     }
   } catch (error) {
     // Silently fail if audio playback is not available or blocked


### PR DESCRIPTION
## Summary

This PR adds a user preference to enable/disable notification sounds, along with audio playback functionality that plays a sound when new notifications arrive.

## Changes Made

### Components
- **NotificationBell** - Added sound playback when new notifications are detected
- **AdminSettingsPage** - Added notification sounds toggle control in settings

### Store
- **uiStore** - Added `notificationSoundsEnabled` state with persistence

### Utilities
- **soundUtils** - New utility module with Web Audio API-based notification sound generation

## How It Works

1. **Sound Generation**: Uses Web Audio API to generate a simple 800Hz sine wave notification tone (200ms duration)
2. **Smart Detection**: Only plays sound when unread count increases (not on initial page load)
3. **User Control**: Users can enable/disable sounds via the Admin Settings page
4. **Persistence**: User preference is persisted in local storage via zustand persist middleware
5. **Graceful Degradation**: Handles browser audio blocking gracefully without errors

## Testing

- Toggle notification sounds on/off in Admin Settings
- Verify sound plays when new notifications arrive (when enabled)
- Verify no sound plays on initial page load
- Verify preference persists across browser sessions

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author