### PR TITLE
feat(AdminOrdersPage): add pagination number dropdown options

### DIFF
--- a/augment-store/client/src/features/admin-dashboard/pages/AdminOrdersPage.tsx
+++ b/augment-store/client/src/features/admin-dashboard/pages/AdminOrdersPage.tsx
@@ -394,12 +394,12 @@ const AdminOrdersPage = () => {
             disabled={isFetchingAdminOrders}
           />
           <FormControl size="small" sx={{ minWidth: 120 }}>
-            <InputLabel id="page-select-label">Go to page</InputLabel>
+            <InputLabel id="page-select-label">{t('admin.ordersPage.pagination.goToPage')}</InputLabel>
             <Select
               labelId="page-select-label"
               id="page-select"
               value={currentAdminPage}
-              label="Go to page"
+              label={t('admin.ordersPage.pagination.goToPage')}
               onChange={(e) => {
                 const newPage = Number(e.target.value)
                 setAdminPage(newPage)
@@ -409,7 +409,7 @@ const AdminOrdersPage = () => {
             >
               {Array.from({ length: totalAdminPages }, (_, i) => i + 1).map((pageNum) => (
                 <MenuItem key={pageNum} value={pageNum}>
-                  Page {pageNum}
+                  {t('admin.ordersPage.pagination.pageNumber', { pageNum })}
                 </MenuItem>
               ))}
             </Select>

--- a/augment-store/client/src/features/admin-dashboard/pages/AdminOrdersPage.tsx
+++ b/augment-store/client/src/features/admin-dashboard/pages/AdminOrdersPage.tsx
@@ -17,6 +17,10 @@ import {
   Alert,
   IconButton,
   Tooltip,
+  Select,
+  MenuItem,
+  FormControl,
+  InputLabel,
 } from '@mui/material'
 import {
   ShoppingCart as ShoppingCartIcon,
@@ -381,7 +385,7 @@ const AdminOrdersPage = () => {
 
       {/* Pagination */}
       {totalAdminPages > 1 && (
-        <Box sx={{ display: 'flex', justifyContent: 'center', mt: 4 }}>
+        <Box sx={{ display: 'flex', justifyContent: 'center', alignItems: 'center', gap: 3, mt: 4, flexWrap: 'wrap' }}>
           <Pagination
             count={totalAdminPages}
             page={currentAdminPage}
@@ -389,6 +393,27 @@ const AdminOrdersPage = () => {
             color="primary"
             disabled={isFetchingAdminOrders}
           />
+          <FormControl size="small" sx={{ minWidth: 120 }}>
+            <InputLabel id="page-select-label">Go to page</InputLabel>
+            <Select
+              labelId="page-select-label"
+              id="page-select"
+              value={currentAdminPage}
+              label="Go to page"
+              onChange={(e) => {
+                const newPage = Number(e.target.value)
+                setAdminPage(newPage)
+                window.scrollTo({ top: 0, behavior: 'smooth' })
+              }}
+              disabled={isFetchingAdminOrders}
+            >
+              {Array.from({ length: totalAdminPages }, (_, i) => i + 1).map((pageNum) => (
+                <MenuItem key={pageNum} value={pageNum}>
+                  Page {pageNum}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
         </Box>
       )}
     </Container>

--- a/augment-store/client/src/locales/de/translation.json
+++ b/augment-store/client/src/locales/de/translation.json
@@ -1022,6 +1022,10 @@
       "emptyState": {
         "noOrders": "Noch Keine Bestellungen",
         "noOrdersDescription": "Es wurden noch keine Kundenbestellungen aufgegeben."
+      },
+      "pagination": {
+        "goToPage": "Zur Seite gehen",
+        "pageNumber": "Seite {{pageNum}}"
       }
     },
     "products": "Produkte",

--- a/augment-store/client/src/locales/en/translation.json
+++ b/augment-store/client/src/locales/en/translation.json
@@ -1022,6 +1022,10 @@
       "emptyState": {
         "noOrders": "No Orders Yet",
         "noOrdersDescription": "No customer orders have been placed yet."
+      },
+      "pagination": {
+        "goToPage": "Go to page",
+        "pageNumber": "Page {{pageNum}}"
       }
     },
     "products": "Products",

--- a/augment-store/client/src/locales/es/translation.json
+++ b/augment-store/client/src/locales/es/translation.json
@@ -1022,6 +1022,10 @@
       "emptyState": {
         "noOrders": "Aún No Hay Pedidos",
         "noOrdersDescription": "Aún no se han realizado pedidos de clientes."
+      },
+      "pagination": {
+        "goToPage": "Ir a la página",
+        "pageNumber": "Página {{pageNum}}"
       }
     },
     "products": "Productos",

--- a/augment-store/client/src/locales/fr/translation.json
+++ b/augment-store/client/src/locales/fr/translation.json
@@ -1022,6 +1022,10 @@
       "emptyState": {
         "noOrders": "Aucune Commande Pour le Moment",
         "noOrdersDescription": "Aucune commande client n'a encore été passée."
+      },
+      "pagination": {
+        "goToPage": "Aller à la page",
+        "pageNumber": "Page {{pageNum}}"
       }
     },
     "products": "Produits",


### PR DESCRIPTION
## Summary

This PR enhances the pagination functionality on the AdminOrdersPage by adding a page-jump dropdown selector alongside the existing pagination controls. This allows administrators to quickly navigate to a specific page number without having to click through multiple pages.

## Changes Made

### Components
- **AdminOrdersPage** - Added a dropdown select control that allows direct navigation to any page number
  - Integrated with existing pagination state management
  - Includes smooth scroll to top behavior on page change
  - Disabled state matches the pagination component for consistency
  - Uses internationalization for labels (i18n support)

### Layout Updates
- Modified pagination container to support both pagination controls and the new dropdown
- Added flexbox layout with gap spacing and flex-wrap for responsive behavior
- Centered alignment for improved visual consistency