### PR TITLE
fix[parser]: preserve for-loop annotation spans

### DIFF
--- a/vyper/tests/unit/ast/test_annotate_and_optimize_ast.py
+++ b/vyper/tests/unit/ast/test_annotate_and_optimize_ast.py
@@ -37,6 +37,16 @@ def get_contract_info(source_code):
     return py_ast, pre_parser.reformatted_code
 
 
+def get_contract_info_with_original_source(source_code):
+    pre_parser = PreParser(is_interface=False)
+    pre_parser.parse(source_code)
+    py_ast = python_ast.parse(pre_parser.reformatted_code)
+
+    annotate_python_ast(py_ast, source_code, pre_parser)
+
+    return py_ast
+
+
 def test_it_annotates_ast_with_source_code():
     contract_ast, reformatted_code = get_contract_info(TEST_CONTRACT_SOURCE_CODE)
 
@@ -65,3 +75,22 @@ def test_it_rewrites_unary_subtractions():
 
     assert isinstance(return_stmt.value, python_ast.Constant)
     assert return_stmt.value.value == -1
+
+
+def test_for_loop_annotation_source_is_spliced_from_real_target():
+    source_code = """
+@external
+def foo():
+    for i: uint256 in range(3):
+        pass
+    """
+    contract_ast = get_contract_info_with_original_source(source_code)
+
+    function_def = contract_ast.body[0]
+    for_node = function_def.body[0]
+    ann_assign = for_node.target
+
+    assert isinstance(ann_assign, python_ast.AnnAssign)
+    assert ann_assign.target.id == "i"
+    assert ann_assign.annotation.id == "uint256"
+    assert ann_assign.node_source_code == "i: uint256"

--- a/vyper/vyper/ast/parse.py
+++ b/vyper/vyper/ast/parse.py
@@ -315,6 +315,47 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
         node.ast_type = self._pre_parser.keyword_translations[(node.lineno, node.col_offset)]
         return node
 
+    def _visit_for_loop_annotation(self, node, annotation_tokens):
+        """
+        Parse and return the type annotation for a Vyper for-loop target.
+
+        The pre-parser removes these annotations from the source presented to
+        Python's parser because PEP-526 does not allow annotated for-loop
+        targets. Parse the removed tokens as an annotated assignment only to
+        obtain the annotation expression, then let the caller construct the
+        actual target node with source locations from the real loop target.
+        """
+        # untokenize preserves the original line and column offsets, giving us
+        # something like `\
+        # \
+        # \
+        #   uint8`. Prefixing a dummy target makes it a valid Python statement
+        # while preserving locations on the annotation expression itself.
+        annotation_str = tokenize.untokenize(annotation_tokens)
+        annotation_str = "dummy_target:" + annotation_str
+
+        try:
+            parsed_node = python_ast.parse(annotation_str).body[0]
+            parsed_node = _deepcopy_ast(parsed_node)
+        except SyntaxError as e:
+            raise SyntaxException(
+                "invalid type annotation", self._source_code, node.lineno, node.col_offset
+            ) from e
+
+        if not isinstance(parsed_node, python_ast.AnnAssign):  # pragma: nocover
+            raise CompilerPanic("Unexpected AST node while parsing for-loop annotation")
+
+        # block things like `for x: uint256 = 5 in ...`
+        if (value_node := parsed_node.value) is not None:
+            raise SyntaxException(
+                "invalid type annotation",
+                self._source_code,
+                value_node.lineno,
+                value_node.col_offset,
+            )
+
+        return parsed_node.annotation
+
     def visit_For(self, node):
         """
         Visit a For node, splicing in the loop variable annotation provided by
@@ -335,45 +376,24 @@ class AnnotatingVisitor(python_ast.NodeTransformer):
                 node.col_offset,
             )
 
-        # some kind of black magic. untokenize preserves the line and column
-        # offsets, giving us something like `\
-        # \
-        # \
-        #   uint8`
-        # that's not a valid python Expr because it is indented.
-        # but it's good because the code is indented to exactly the same
-        # offset as it did in the original source!
-        # (to best understand this, print out annotation_str and
-        # self._source_code and compare them side-by-side).
-        #
-        # what we do here is add in a dummy target which we will remove
-        # in a bit, but for now lets us keep the line/col offset, and
-        # *also* gives us a valid AST. it doesn't matter what the dummy
-        # target name is, since it gets removed in a few lines.
-        annotation_str = tokenize.untokenize(annotation_tokens)
-        annotation_str = "dummy_target:" + annotation_str
+        annotation = self._visit_for_loop_annotation(node, annotation_tokens)
+        target = node.target
 
-        try:
-            fake_node = python_ast.parse(annotation_str).body[0]
-            # do we need to fix location info here?
-            fake_node = _deepcopy_ast(fake_node)
-        except SyntaxError as e:
-            raise SyntaxException(
-                "invalid type annotation", self._source_code, node.lineno, node.col_offset
-            ) from e
-        # block things like `for x: uint256 = 5 in ...`
-        if (value_node := fake_node.value) is not None:
-            raise SyntaxException(
-                "invalid type annotation",
-                self._source_code,
-                value_node.lineno,
-                value_node.col_offset,
-            )
-
-        # replace the dummy target name with the real target name.
-        fake_node.target = node.target
-        # replace the For node target with the new ann_assign
-        node.target = fake_node
+        # Replace the For node target with an AnnAssign representing the Vyper
+        # loop variable declaration. Constructing the node directly avoids
+        # mutating the temporary AST used to parse the annotation and keeps the
+        # source range pinned to the real target and annotation.
+        ann_assign = python_ast.AnnAssign(
+            target=target,
+            annotation=annotation,
+            value=None,
+            simple=int(isinstance(target, python_ast.Name)),
+        )
+        ann_assign.lineno = target.lineno
+        ann_assign.col_offset = target.col_offset
+        ann_assign.end_lineno = annotation.end_lineno
+        ann_assign.end_col_offset = annotation.end_col_offset
+        node.target = ann_assign
 
         return self.generic_visit(node)
 


### PR DESCRIPTION
### What I did

- added a dedicated `_visit_for_loop_annotation` helper in `AnnotatingVisitor`
- removed the old for-loop annotation `fake_node` target swapping path
- made `visit_For` build the synthetic `AnnAssign` directly from the real
  loop target and parsed annotation span
- added unit coverage for the synthesized `AnnAssign.node_source_code`
  value on annotated for-loops

### How I did it

The pre-parser still supplies the removed annotation tokens, but the parser
now handles them through a dedicated helper that parses the temporary
annotated assignment only far enough to extract the annotation expression.

`visit_For` then constructs the final `python_ast.AnnAssign` explicitly from
`node.target` plus that parsed annotation, instead of mutating a temporary
parsed node in place. This keeps the source range tied to the real target
span while preserving the existing invalid-annotation checks.

### How to verify it

- `python -m py_compile vyper/ast/parse.py tests/unit/ast/test_annotate_and_optimize_ast.py`
- `git diff --check`
- isolated smoke check confirmed the synthesized for-loop target reports
  `node_source_code == "i: uint256"`
- `python -m pytest tests/unit/ast/test_annotate_and_optimize_ast.py -q`
  is currently blocked in this environment because `pytest` is not installed

### Commit message

The parser previously handled annotated for-loop targets by parsing a dummy
`AnnAssign` and then swapping its target in place. That left source-range
metadata tied to the temporary node shape, which made source splicing for
loop annotations harder to reason about and more fragile.

Parse the removed annotation tokens in a dedicated helper and return only
the annotation expression. `visit_For` now builds the final `AnnAssign`
directly from the real loop target, so the resulting node is constructed
explicitly around the source span we actually want to preserve.

Add a unit test that checks the synthesized target keeps
`node_source_code` aligned with the original source for for-loop
annotations.

### Description for the changelog

Improve parser handling for annotated for-loop targets and preserve their
source spans.

### Cute Animal Picture

![Cute animal picture](https://placebear.com/640/360)


---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KSFTNSDQG32GYDXPS1Y2MD51&panel=chat)