### PR TITLE
Fix JWT expiry logout loop

### DIFF
--- a/idurar-erp-crm/frontend/src/request/errorHandler.js
+++ b/idurar-erp-crm/frontend/src/request/errorHandler.js
@@ -1,6 +1,46 @@
 import { notification } from 'antd';
 import codeMessage from './codeMessage';
 
+const SESSION_EXPIRED_LOGOUT_PATH = '/logout?reason=session-expired';
+const sessionExpiredResponse = {
+  success: false,
+  result: null,
+  message: 'Your session expired. Please sign in again to continue.',
+};
+
+let isSessionExpiredLogoutInProgress = false;
+
+const clearAuthState = () => {
+  window.localStorage.removeItem('auth');
+  window.localStorage.removeItem('settings');
+  window.localStorage.removeItem('isLogout');
+};
+
+const handleSessionExpired = () => {
+  if (isSessionExpiredLogoutInProgress) {
+    return sessionExpiredResponse;
+  }
+
+  isSessionExpiredLogoutInProgress = true;
+  clearAuthState();
+
+  notification.config({
+    duration: 8,
+    maxCount: 1,
+  });
+  notification.warning({
+    key: 'session-expired',
+    message: 'Session expired',
+    description: sessionExpiredResponse.message,
+  });
+
+  if (window.location.pathname !== '/logout') {
+    window.location.replace(SESSION_EXPIRED_LOGOUT_PATH);
+  }
+
+  return sessionExpiredResponse;
+};
+
 const errorHandler = (error) => {
   if (!navigator.onLine) {
     notification.config({
@@ -39,21 +79,18 @@ const errorHandler = (error) => {
   }
 
   if (response && response.data && response.data.jwtExpired) {
-    const result = window.localStorage.getItem('auth');
-    const jsonFile = window.localStorage.getItem('isLogout');
-    const { isLogout } = (jsonFile && JSON.parse(jsonFile)) || false;
-    window.localStorage.removeItem('auth');
-    window.localStorage.removeItem('isLogout');
-    if (result || isLogout) {
-      window.location.href = '/logout';
-    }
+    return handleSessionExpired();
   }
 
   if (response && response.status) {
+    if (response?.data?.error?.name === 'JsonWebTokenError') {
+      return handleSessionExpired();
+    }
+
     const message = response.data && response.data.message;
 
     const errorText = message || codeMessage[response.status];
-    const { status, error } = response;
+    const { status } = response;
     notification.config({
       duration: 20,
       maxCount: 2,
@@ -63,11 +100,7 @@ const errorHandler = (error) => {
       description: errorText,
     });
 
-    if (response?.data?.error?.name === 'JsonWebTokenError') {
-      window.localStorage.removeItem('auth');
-      window.localStorage.removeItem('isLogout');
-      window.location.href = '/logout';
-    } else return response.data;
+    return response.data;
   } else {
     notification.config({
       duration: 15,

--- a/idurar-erp-crm/frontend/src/router/AuthRouter.jsx
+++ b/idurar-erp-crm/frontend/src/router/AuthRouter.jsx
@@ -1,4 +1,6 @@
-import { Routes, Route, Navigate } from 'react-router-dom';
+import { useEffect } from 'react';
+import { Routes, Route, useLocation, useNavigate } from 'react-router-dom';
+import { notification } from 'antd';
 
 import Login from '@/pages/Login';
 import NotFound from '@/pages/NotFound';
@@ -6,16 +8,37 @@ import NotFound from '@/pages/NotFound';
 import ForgetPassword from '@/pages/ForgetPassword';
 import ResetPassword from '@/pages/ResetPassword';
 
-import { useDispatch } from 'react-redux';
+const SessionExpiredRedirect = () => {
+  const location = useLocation();
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const params = new URLSearchParams(location.search);
+
+    if (params.get('reason') === 'session-expired') {
+      notification.config({
+        duration: 8,
+        maxCount: 1,
+      });
+      notification.warning({
+        key: 'session-expired',
+        message: 'Session expired',
+        description: 'Your session expired. Please sign in again to continue.',
+      });
+    }
+
+    navigate('/login', { replace: true });
+  }, [location.search, navigate]);
+
+  return null;
+};
 
 export default function AuthRouter() {
-  const dispatch = useDispatch();
-
   return (
     <Routes>
       <Route element={<Login />} path="/" />
       <Route element={<Login />} path="/login" />
-      <Route element={<Navigate to="/login" replace />} path="/logout" />
+      <Route element={<SessionExpiredRedirect />} path="/logout" />
       <Route element={<ForgetPassword />} path="/forgetpassword" />
       <Route element={<ResetPassword />} path="/resetpassword/:userId/:resetToken" />
       <Route path="*" element={<NotFound />} />


### PR DESCRIPTION
## Summary
- Add a single guarded session-expiry handler for jwtExpired and JsonWebTokenError responses.
- Clear stale auth state once, replace the browser history entry with the logout route, and return a friendly expired-session response instead of falling through to generic request errors.
- Teach the unauthenticated /logout route to show a session-expired notice before sending the user back to login.

## Validation
- git diff --check
- node --check idurar-erp-crm/frontend/src/request/errorHandler.js
- npm run build (blocked: frontend dependencies are not installed, so vite is not available)

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) | [View session](https://cosmos.augmentcode.com/session?agentId=01KSQ2KX1DT8R2CM4WP75E93W1&panel=chat)