### PR TITLE
feat: integrate the form cycle endpoint

### DIFF
--- a/qualia/frontend/src/hooks/useCreateFormCycle.ts
+++ b/qualia/frontend/src/hooks/useCreateFormCycle.ts
@@ -35,7 +35,7 @@ export const useCreateFormCycle = (options?: {
   onSuccess?: (data: CreateFormCycleResponse) => void;
   onError?: (error: ApiError) => void;
 }) => {
-  return useMutation({
+  return useMutation<CreateFormCycleResponse, ApiError, CreateFormCycleRequest>({
     mutationFn: (data: CreateFormCycleRequest) => createFormCycle(data),
     onSuccess: options?.onSuccess,
     onError: options?.onError,

--- a/qualia/frontend/src/hooks/useCreateFormCycle.ts
+++ b/qualia/frontend/src/hooks/useCreateFormCycle.ts
@@ -1,4 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
+import { createFormCycle } from '@/services/formService';
 import type { CreateFormCycleRequest, CreateFormCycleResponse } from '@/services/formService';
 import type { ApiError } from '@/lib/axios';
 
@@ -31,7 +32,8 @@ import type { ApiError } from '@/lib/axios';
  * ```
  */
 export const useCreateFormCycle = (options?: {
-  onSuccess?: (data: string) => void;
+  onSuccess?: (data: CreateFormCycleResponse) => void;
+  onError?: (error: ApiError) => void;
 }) => {
   return useMutation({
     mutationFn: (data: CreateFormCycleRequest) => createFormCycle(data),
@@ -39,6 +41,6 @@ export const useCreateFormCycle = (options?: {
     onError: options?.onError,
     // Disable retry to prevent duplicate form cycle creation on transient failures
     // Form cycle creation is non-idempotent, so retrying could create multiple cycles
-    retry: true,
+    retry: false,
   });
 };

--- a/qualia/frontend/src/hooks/useCreateFormCycle.ts
+++ b/qualia/frontend/src/hooks/useCreateFormCycle.ts
@@ -26,7 +26,7 @@ import type { ApiError } from '@/lib/axios';
  * // Call the mutation
  * mutate({
  *   title: "Q2 2026 QA Cycle",
- *   description: "Quarterly QA review",
+ *   description: "Quarterly QA review for all team members",
  *   submission_deadline: "2026-06-30T23:59:59+00:00"
  * });
  * ```

--- a/qualia/frontend/src/hooks/useCreateFormCycle.ts
+++ b/qualia/frontend/src/hooks/useCreateFormCycle.ts
@@ -1,0 +1,44 @@
+import { useMutation } from '@tanstack/react-query';
+import type { CreateFormCycleRequest, CreateFormCycleResponse } from '@/services/formService';
+import type { ApiError } from '@/lib/axios';
+
+/**
+ * TanStack Query mutation hook for creating a form cycle
+ *
+ * Disables retry to prevent duplicate form cycle creation on transient
+ * network failures (form cycle creation is non-idempotent).
+ *
+ * @example
+ * ```tsx
+ * const { mutate, isPending, isError, error, data } = useCreateFormCycle({
+ *   onSuccess: (data) => {
+ *     console.log('Form cycle created:', data.id);
+ *     toast.success(`Form cycle created with ID: ${data.id}`);
+ *     navigate(`/dashboard/forms/${data.id}`);
+ *   },
+ *   onError: (error) => {
+ *     console.error('Form cycle creation failed:', error.message);
+ *     toast.error(error.message);
+ *   }
+ * });
+ *
+ * // Call the mutation
+ * mutate({
+ *   title: "Q2 2026 QA Cycle",
+ *   description: "Quarterly QA review",
+ *   submission_deadline: "2026-06-30T23:59:59+00:00"
+ * });
+ * ```
+ */
+export const useCreateFormCycle = (options?: {
+  onSuccess?: (data: string) => void;
+}) => {
+  return useMutation({
+    mutationFn: (data: CreateFormCycleRequest) => createFormCycle(data),
+    onSuccess: options?.onSuccess,
+    onError: options?.onError,
+    // Disable retry to prevent duplicate form cycle creation on transient failures
+    // Form cycle creation is non-idempotent, so retrying could create multiple cycles
+    retry: true,
+  });
+};

--- a/qualia/frontend/src/services/formService.ts
+++ b/qualia/frontend/src/services/formService.ts
@@ -53,7 +53,7 @@ export const createFormCycle = async (data: CreateFormCycleRequest): Promise<Cre
     });
   }
 
-  const response = await apiClient.post<CreateFormCycleResponse>('/form', data);
+  const response = await apiClient.post<CreateFormCycleResponse>('/forms', data);
 
   // Debug logging in development
   if (import.meta.env.DEV) {

--- a/qualia/frontend/src/services/formService.ts
+++ b/qualia/frontend/src/services/formService.ts
@@ -12,7 +12,7 @@ import { apiClient } from '@/lib/axios';
  */
 export interface CreateFormCycleRequest {
   title: string;
-  description: Array<number>;
+  description?: string | null;
   submission_deadline: string; // ISO 8601 format with timezone (e.g., "2026-06-30T23:59:59+00:00")
 }
 
@@ -36,7 +36,7 @@ export interface CreateFormCycleResponse {
  * ```typescript
  * const formCycle = await createFormCycle({
  *   title: "Q2 2026 QA Cycle",
- *   description: "Quarterly QA review",
+ *   description: "Quarterly QA review for all team members",
  *   submission_deadline: "2026-06-30T23:59:59+00:00"
  * });
  * console.log(formCycle.id); // "550e8400-e29b-41d4-a716-446655440000"

--- a/qualia/frontend/src/services/formService.ts
+++ b/qualia/frontend/src/services/formService.ts
@@ -45,8 +45,8 @@ export interface CreateFormCycleResponse {
  */
 export const createFormCycle = async (data: CreateFormCycleRequest): Promise<CreateFormCycleResponse> => {
   // Debug logging in development
-  if (import.meta.DEV) {
-    console.log('Create form cycle request:', { 
+  if (import.meta.env.DEV) {
+    console.log('Create form cycle request:', {
       endpoint: '/forms',
       title: data.title,
       deadline: data.submission_deadline

--- a/qualia/frontend/src/services/formService.ts
+++ b/qualia/frontend/src/services/formService.ts
@@ -1,0 +1,67 @@
+import { apiClient } from '@/lib/axios';
+
+/**
+ * Form Cycle API service
+ * Handles form cycle creation and management
+ */
+
+// Type definitions matching backend API
+
+/**
+ * Request payload for creating a new form cycle
+ */
+export interface CreateFormCycleRequest {
+  title: string;
+  description: Array<number>;
+  submission_deadline: string; // ISO 8601 format with timezone (e.g., "2026-06-30T23:59:59+00:00")
+}
+
+/**
+ * Response from creating a form cycle
+ */
+export interface CreateFormCycleResponse {
+  id: string;
+  status: string;
+}
+
+/**
+ * Create a new form cycle
+ * @param data - Form cycle data (title, description, submission_deadline)
+ * @returns Promise with form cycle creation response
+ * @throws When the API request fails, throws an error object produced by apiClient interceptors
+ *         (see ApiError interface in @/lib/axios) with properties: status?, message, data?, originalError.
+ *         This includes network errors, validation errors, permission errors, and server errors.
+ * 
+ * @example
+ * ```typescript
+ * const formCycle = await createFormCycle({
+ *   title: "Q2 2026 QA Cycle",
+ *   description: "Quarterly QA review",
+ *   submission_deadline: "2026-06-30T23:59:59+00:00"
+ * });
+ * console.log(formCycle.id); // "550e8400-e29b-41d4-a716-446655440000"
+ * console.log(formCycle.status); // "draft"
+ * ```
+ */
+export const createFormCycle = async (data: CreateFormCycleRequest): Promise<CreateFormCycleResponse> => {
+  // Debug logging in development
+  if (import.meta.DEV) {
+    console.log('Create form cycle request:', { 
+      endpoint: '/forms',
+      title: data.title,
+      deadline: data.submission_deadline
+    });
+  }
+
+  const response = await apiClient.post<CreateFormCycleResponse>('/form', data);
+
+  // Debug logging in development
+  if (import.meta.env.DEV) {
+    console.log('Create form cycle response:', { 
+      id: response.data.id,
+      status: response.data.status
+    });
+  }
+
+  return response.data;
+};


### PR DESCRIPTION
# Integrate Form Cycle Creation Endpoint

## Summary
Integrated the backend form cycle creation API endpoint into the frontend application, providing a type-safe service layer and React Query mutation hook for creating form cycles.

## Changes

### 🔧 API Service Layer

#### **formService.ts** - Form Cycle API Service (NEW)
- Created `createFormCycle` function to handle form cycle creation API calls
- **Type Definitions**:
  - `CreateFormCycleRequest`: Request payload interface with `title`, `description` (optional string), and `submission_deadline` (ISO 8601 string)
  - `CreateFormCycleResponse`: Response interface with `id` and `status` fields
- **API Integration**:
  - POST endpoint: `/forms`
  - Uses centralized `apiClient` from `@/lib/axios`
  - Proper error handling via apiClient interceptors
  - Development-mode debug logging for requests and responses
- **Documentation**:
  - Comprehensive JSDoc comments
  - Usage examples with realistic data
  - Clear error throwing documentation

### ⚡ React Query Integration

#### **useCreateFormCycle.ts** - TanStack Query Mutation Hook (NEW)
- Created custom React Query mutation hook for form cycle creation
- **Key Features**:
  - Wraps `createFormCycle` service function in TanStack Query mutation
  - Configurable `onSuccess` and `onError` callbacks
  - **Retry disabled** (important: form cycle creation is non-idempotent)
  - Prevents duplicate form cycles on transient network failures
- **Type Safety**:
  - Fully typed with TypeScript
  - Generic types for `CreateFormCycleRequest` and `CreateFormCycleResponse`
  - Typed `ApiError` for error handling
- **Usage Example**:
  ```tsx
  const { mutate, isPending, isError, error, data } = useCreateFormCycle({
    onSuccess: (data) => {
      toast.success(`Form cycle created with ID: ${data.id}`);
      navigate(`/dashboard/forms/${data.id}`);
    },
    onError: (error) => {
      toast.error(error.message);
    }
  });

  // Trigger the mutation
  mutate({
    title: "Q2 2026 QA Cycle",
    description: "Quarterly QA review for all team members",
    submission_deadline: "2026-06-30T23:59:59+00:00"
  });
  ```

## Technical Details

### API Contract
- **Endpoint**: `POST /forms`
- **Request Body**:
  ```typescript
  {
    title: string;
    description?: string | null;
    submission_deadline: string; // ISO 8601 with timezone
  }
  ```
- **Response**:
  ```typescript
  {
    id: string;        // UUID of created form cycle
    status: string;    // e.g., "draft"
  }
  ```

### Error Handling
- All errors thrown by `createFormCycle` conform to the `ApiError` interface
- Errors include: network failures, validation errors, permission errors, server errors
- Error properties: `status?`, `message`, `data?`, `originalError`
- Handled by centralized axios interceptors

### Non-Idempotent Operation
- Form cycle creation cannot be safely retried automatically
- `retry: false` prevents TanStack Query from creating duplicate form cycles
- Network failures should be handled by user retry (via UI) not automatic retry

## Files Added
- ➕ Added: `src/services/formService.ts` (68 lines)
- ➕ Added: `src/hooks/useCreateFormCycle.ts` (47 lines)

## Testing Recommendations
- [ ] Verify `createFormCycle` makes correct API call to `/forms` endpoint
- [ ] Test successful form cycle creation flow
- [ ] Test error handling for network failures
- [ ] Test error handling for validation errors (invalid deadline, missing title, etc.)
- [ ] Verify `onSuccess` callback receives correct response data
- [ ] Verify `onError` callback receives proper ApiError object
- [ ] Confirm retry is disabled (check that transient failures don't create duplicates)
- [ ] Test with real backend API integration
- [ ] Verify TypeScript types match backend contract
- [ ] Test development-mode debug logging

## Design Decisions

### Why Disable Retry?
- Form cycle creation is **non-idempotent** (creates a new resource each time)
- Automatic retries on network failures could create duplicate form cycles
- Better to fail fast and let user retry via UI if needed
- Prevents subtle bugs from transient network issues

### Why Separate Service and Hook?
- **Service layer** (`formService.ts`): Pure API logic, reusable, testable
- **Hook layer** (`useCreateFormCycle.ts`): React-specific, handles mutation state, UI integration
- Clear separation of concerns
- Service can be used in tests or non-React contexts
- Hook provides convenient mutation state management

### Why Optional String for Description?
- Matches backend API contract
- Description is optional and accepts a string value
- Frontend can provide formatted text or leave it null

## Future Enhancements
- Implement form cycle listing/fetching
- Add form cycle update/delete endpoints
- Implement optimistic updates for better UX
- Add query invalidation on successful creation
- Create form builder UI to use this mutation
- Add form cycle status transitions

## Integration Points

### Dependencies Used
- **@tanstack/react-query**: Mutation state management
- **@/lib/axios**: Centralized HTTP client with interceptors
- **TypeScript**: Full type safety across service and hook

### Ready for Integration
- This PR provides the **foundation** for form cycle creation
- UI components can now import `useCreateFormCycle` and create form cycles
- Service layer ready for additional form-related endpoints

---

**Note**: This PR focuses solely on the API integration layer for form cycle creation. UI components to consume this hook will be added in future PRs.