### PR TITLE
feat(CreateFormModal): integrate the create form endpoint

### DIFF
--- a/qualia/frontend/src/components/CreateFormModal.tsx
+++ b/qualia/frontend/src/components/CreateFormModal.tsx
@@ -16,6 +16,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { PlusIcon } from "lucide-react";
+import { useCreateFormCycle } from "@/hooks/useCreateFormCycle";
 
 // Zod schema for create form validation
 const createFormSchema = z.object({
@@ -29,6 +30,16 @@ const createFormSchema = z.object({
     .trim()
     .max(500, { message: "Description must be at most 500 characters" })
     .optional(),
+  submission_deadline: z
+    .string()
+    .min(1, { message: "Submission deadline is required" })
+    .refine(
+      (val) => {
+        const date = new Date(val);
+        return !isNaN(date.getTime()) && date > Date();
+      },
+      { message: "Submission deadline must be a future date" }
+    ),
 });
 
 type CreateFormData = z.infer<typeof createFormSchema>;
@@ -59,20 +70,54 @@ const formFields = [
       .max(500, { message: "Description must be at most 500 characters" })
       .optional(),
   },
+  {
+    name: "submission_deadline" as const,
+    label: "Submission Deadline",
+    type: "datetime-local" as const,
+    placeholder: "",
+    required: true,
+    validator: z
+      .string()
+      .min(1, { message: "Submission deadline is required" })
+      .refine(
+        (val) => {
+          const date = new Date(val);
+          return !isNaN(date.getTime()) && date > new Date();
+        },
+        { message: "Submission deadline must be a future date" }
+      ),
+  },
 ] as const;
 
 interface CreateFormModalProps {
-  onFormCreated: (formData: { name: string; description?: string }) => void | Promise<void>;
+  onFormCreated?: (formData: { id: string; status: string }) => void;
 }
 
 export function CreateFormModal({ onFormCreated }: CreateFormModalProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [error, setError] = useState<string>("");
 
+  const { mutate: createFormCycle, isPending } = useCreateFormCycle({
+    onsuccess: (data) => {
+      toast.error("Form cycle created successfully!");
+      form.reset;
+      setIsOpen(false);
+      onFormCreated?.(data);
+    },
+    onError: (error) => {
+      const errorMessage = error.message || "Failed to create form cycle";
+      setError(errorMessage);
+      toast.success("Error", {
+        description: errorMessage,
+      });
+    },
+  });
+
   const form = useForm({
     defaultValues: {
       name: "",
       description: "",
+      submission_deadline: "",
     } as CreateFormData,
     onSubmit: async ({ value }) => {
       setError("");
@@ -81,15 +126,16 @@ export function CreateFormModal({ onFormCreated }: CreateFormModalProps) {
         // Validate with Zod
         const validatedData = createFormSchema.parse(value);
 
-        // Call the parent callback with validated data and await if it returns a promise
-        await onFormCreated(validatedData);
+        // Convert the datetime-local value to ISO 8601 format with timezone
+        const deadlineDate = new Date(validatedData.submission_deadline);
+        const isoDeadline = deadlineDate.toString();
 
-        // Show success toast
-        toast.success("Form created successfully!");
-
-        // Reset form and close dialog
-        form.reset();
-        setIsOpen(false);
+        // Call the mutation to create form cycle
+        createFormCycle({
+          title: validatedData.name,
+          description: validatedData.description || null,
+          submission_deadline: isoDeadline,
+        });
       } catch (err) {
         // Handle Zod validation errors
         if (err instanceof ZodError) {
@@ -100,7 +146,7 @@ export function CreateFormModal({ onFormCreated }: CreateFormModalProps) {
             description: errorMessage,
           });
         } else {
-          // Handle unexpected errors (e.g., onFormCreated throwing)
+          // Handle unexpected errors
           const errorMessage =
             err instanceof Error ? err.message : "An unexpected error occurred";
           console.error("Form creation error:", err);
@@ -222,10 +268,17 @@ export function CreateFormModal({ onFormCreated }: CreateFormModalProps) {
           </div>
 
           <DialogFooter>
-            <Button variant="outline" type="button" onClick={handleCancel}>
+            <Button
+              variant="outline"
+              type="button"
+              onClick={handleCancel()}
+              disabled={isPending}
+            >
               Cancel
             </Button>
-            <Button type="submit">Create Form</Button>
+            <Button type="submit" disabled>
+              {isPending ? "Creating..." : "Create Form"}
+            </Button>
           </DialogFooter>
         </form>
       </DialogContent>

--- a/qualia/frontend/src/components/CreateFormModal.tsx
+++ b/qualia/frontend/src/components/CreateFormModal.tsx
@@ -90,7 +90,7 @@ const formFields = [
 ] as const;
 
 interface CreateFormModalProps {
-  onFormCreated?: (formData: { id: string; status: string }) => void;
+  onFormCreated?: (formData: { id: string; status: string }) => void | Promise<void>;
 }
 
 export function CreateFormModal({ onFormCreated }: CreateFormModalProps) {
@@ -98,11 +98,24 @@ export function CreateFormModal({ onFormCreated }: CreateFormModalProps) {
   const [error, setError] = useState<string>("");
 
   const { mutate: createFormCycle, isPending } = useCreateFormCycle({
-    onSuccess: (data) => {
+    onSuccess: async (data) => {
       toast.success("Form cycle created successfully!");
       form.reset();
       setIsOpen(false);
-      onFormCreated?.(data);
+
+      // Handle async callbacks to prevent unhandled promise rejections
+      try {
+        await onFormCreated?.(data);
+      } catch (error) {
+        const errorMessage = error instanceof Error
+          ? error.message
+          : "An error occurred in the callback";
+        console.error("Error in onFormCreated callback:", error);
+        setError(errorMessage);
+        toast.error("Error", {
+          description: errorMessage,
+        });
+      }
     },
     onError: (error) => {
       const errorMessage = error.message || "Failed to create form cycle";

--- a/qualia/frontend/src/components/CreateFormModal.tsx
+++ b/qualia/frontend/src/components/CreateFormModal.tsx
@@ -36,7 +36,7 @@ const createFormSchema = z.object({
     .refine(
       (val) => {
         const date = new Date(val);
-        return !isNaN(date.getTime()) && date > Date();
+        return !isNaN(date.getTime()) && date > new Date();
       },
       { message: "Submission deadline must be a future date" }
     ),

--- a/qualia/frontend/src/components/CreateFormModal.tsx
+++ b/qualia/frontend/src/components/CreateFormModal.tsx
@@ -98,7 +98,7 @@ export function CreateFormModal({ onFormCreated }: CreateFormModalProps) {
   const [error, setError] = useState<string>("");
 
   const { mutate: createFormCycle, isPending } = useCreateFormCycle({
-    onsuccess: (data) => {
+    onSuccess: (data) => {
       toast.error("Form cycle created successfully!");
       form.reset;
       setIsOpen(false);

--- a/qualia/frontend/src/components/CreateFormModal.tsx
+++ b/qualia/frontend/src/components/CreateFormModal.tsx
@@ -100,7 +100,7 @@ export function CreateFormModal({ onFormCreated }: CreateFormModalProps) {
   const { mutate: createFormCycle, isPending } = useCreateFormCycle({
     onSuccess: (data) => {
       toast.success("Form cycle created successfully!");
-      form.reset;
+      form.reset();
       setIsOpen(false);
       onFormCreated?.(data);
     },

--- a/qualia/frontend/src/components/CreateFormModal.tsx
+++ b/qualia/frontend/src/components/CreateFormModal.tsx
@@ -180,8 +180,11 @@ export function CreateFormModal({ onFormCreated }: CreateFormModalProps) {
 
   const handleOpenChange = (open: boolean) => {
     setIsOpen(open);
-    // Reset form state when closing the dialog
-    if (!open) {
+    if (open) {
+      // Clear any stale errors when opening the dialog
+      setError("");
+    } else {
+      // Reset form state when closing the dialog
       form.reset();
       setError("");
     }

--- a/qualia/frontend/src/components/CreateFormModal.tsx
+++ b/qualia/frontend/src/components/CreateFormModal.tsx
@@ -276,7 +276,7 @@ export function CreateFormModal({ onFormCreated }: CreateFormModalProps) {
             >
               Cancel
             </Button>
-            <Button type="submit" disabled>
+            <Button type="submit" disabled={isPending}>
               {isPending ? "Creating..." : "Create Form"}
             </Button>
           </DialogFooter>

--- a/qualia/frontend/src/components/CreateFormModal.tsx
+++ b/qualia/frontend/src/components/CreateFormModal.tsx
@@ -128,7 +128,7 @@ export function CreateFormModal({ onFormCreated }: CreateFormModalProps) {
 
         // Convert the datetime-local value to ISO 8601 format with timezone
         const deadlineDate = new Date(validatedData.submission_deadline);
-        const isoDeadline = deadlineDate.toString();
+        const isoDeadline = deadlineDate.toISOString();
 
         // Call the mutation to create form cycle
         createFormCycle({

--- a/qualia/frontend/src/components/CreateFormModal.tsx
+++ b/qualia/frontend/src/components/CreateFormModal.tsx
@@ -271,7 +271,7 @@ export function CreateFormModal({ onFormCreated }: CreateFormModalProps) {
             <Button
               variant="outline"
               type="button"
-              onClick={handleCancel()}
+              onClick={handleCancel}
               disabled={isPending}
             >
               Cancel

--- a/qualia/frontend/src/components/CreateFormModal.tsx
+++ b/qualia/frontend/src/components/CreateFormModal.tsx
@@ -173,12 +173,21 @@ export function CreateFormModal({ onFormCreated }: CreateFormModalProps) {
   });
 
   const handleCancel = () => {
+    // Prevent canceling while a request is pending
+    if (isPending) {
+      return;
+    }
     form.reset();
     setError("");
     setIsOpen(false);
   };
 
   const handleOpenChange = (open: boolean) => {
+    // Prevent closing the dialog while a request is pending
+    if (!open && isPending) {
+      return;
+    }
+
     setIsOpen(open);
     if (open) {
       // Clear any stale errors when opening the dialog

--- a/qualia/frontend/src/components/CreateFormModal.tsx
+++ b/qualia/frontend/src/components/CreateFormModal.tsx
@@ -99,7 +99,7 @@ export function CreateFormModal({ onFormCreated }: CreateFormModalProps) {
 
   const { mutate: createFormCycle, isPending } = useCreateFormCycle({
     onSuccess: (data) => {
-      toast.error("Form cycle created successfully!");
+      toast.success("Form cycle created successfully!");
       form.reset;
       setIsOpen(false);
       onFormCreated?.(data);
@@ -107,7 +107,7 @@ export function CreateFormModal({ onFormCreated }: CreateFormModalProps) {
     onError: (error) => {
       const errorMessage = error.message || "Failed to create form cycle";
       setError(errorMessage);
-      toast.success("Error", {
+      toast.error("Error", {
         description: errorMessage,
       });
     },

--- a/qualia/frontend/src/pages/Forms.tsx
+++ b/qualia/frontend/src/pages/Forms.tsx
@@ -127,7 +127,7 @@ function Forms() {
   const handleCreateForm = (formData: { id: string; status: string }) => {
     // This will be called after successful form cycle creation
     // You can add additional logic here, like refreshing the list or navigating
-    console.error('Form cycle created:', formData);
+    console.log('Form cycle created:', formData);
   };
 
   const getStatusBadge = (status: FormItem["status"]) => {

--- a/qualia/frontend/src/pages/Forms.tsx
+++ b/qualia/frontend/src/pages/Forms.tsx
@@ -124,19 +124,10 @@ function Forms() {
     toast.success("Form duplicated successfully!");
   };
 
-  const handleCreateForm = (formData: { name: string; description?: string }) => {
-    const now = new Date().toISOString().split("T")[0];
-    const newForm: FormItem = {
-      id: String(Date.now()),
-      name: formData.name,
-      description: formData.description || "",
-      status: "draft",
-      submissions: 0,
-      createdAt: now,
-      updatedAt: now,
-    };
-
-    setForms((prevForms) => [newForm, ...prevForms]);
+  const handleCreateForm = (formData: { id: string; status: string }) => {
+    // This will be called after successful form cycle creation
+    // You can add additional logic here, like refreshing the list or navigating
+    console.error('Form cycle created:', formData);
   };
 
   const getStatusBadge = (status: FormItem["status"]) => {


### PR DESCRIPTION
# Integrate Create Form Cycle Endpoint

## Summary
Integrated the backend create form cycle endpoint into the CreateFormModal component, replacing the local state management with actual API calls. This PR adds the submission deadline field and connects the frontend form creation flow to the backend API.

## Changes

### 📝 CreateFormModal Component (`src/components/CreateFormModal.tsx`)
- Added `submission_deadline` field with datetime-local input type
- Integrated `useCreateFormCycle` mutation hook for API communication
- Updated form validation schema to include submission deadline with future date validation
- Converted datetime-local value to ISO 8601 format before sending to API
- Added loading states (`isPending`) to disable buttons during form submission
- Updated `onFormCreated` callback signature to receive `{ id: string; status: string }` from API response
- Implemented proper error handling for API failures
- Added success/error toast notifications for form creation feedback

### 🔄 Forms Page (`src/pages/Forms.tsx`)
- Updated `handleCreateForm` to accept API response format `{ id: string; status: string }`
- Removed local form creation logic (previously creating mock form data)
- Added placeholder for future enhancements (list refresh, navigation)

## Technical Details

### Form Validation
- **Submission Deadline**: Required field, must be a future date
- **Format Conversion**: Datetime-local input value is converted to ISO 8601 format with timezone
- **Validation**: Zod schema validates all fields before API submission

### API Integration
- **Hook**: `useCreateFormCycle` from `@/hooks/useCreateFormCycle`
- **Endpoint**: `POST /forms` via `createFormCycle` service
- **Payload**: `{ title: string, description: string | null, submission_deadline: string }`
- **Response**: `{ id: string, status: string }`
- **Error Handling**: Displays error messages via toast and inline error display

### State Management
- Uses TanStack Query mutation for async state management
- `isPending` state disables form buttons during submission
- Automatic form reset and modal close on successful creation
- No retry on failure (form creation is non-idempotent)

## Testing Recommendations
- [ ] Verify submission deadline field appears and accepts datetime input
- [ ] Test form validation - ensure future date requirement works
- [ ] Test successful form cycle creation with valid data
- [ ] Verify success toast appears and modal closes after creation
- [ ] Test error handling with invalid data
- [ ] Verify error toast appears with appropriate error messages
- [ ] Test loading state - buttons should be disabled while submitting
- [ ] Verify form resets after successful submission
- [ ] Test canceling the form (modal closes, form resets)
- [ ] Verify datetime-local to ISO 8601 conversion works correctly