### PR TITLE
feat: add get assigned forms endpoint

### DIFF
--- a/qualia/frontend/src/hooks/useAssignedForms.ts
+++ b/qualia/frontend/src/hooks/useAssignedForms.ts
@@ -65,7 +65,7 @@ export const useAssignedForms = (options?: {
 
   return useQuery<AssignedForm[], ApiError>({
     queryKey: ['assignedForms', userId], // Scoped to user ID to prevent cache sharing between users
-    queryFn: () => getAssignedForms(),
+    queryFn: ({ signal }) => getAssignedForms(signal),
     enabled: isEnabled, // Only fetch when authenticated and not explicitly disabled
     // Query will automatically retry 3 times (from global config in queryClient.ts)
     // Data is considered fresh for 5 minutes (from global config)

--- a/qualia/frontend/src/hooks/useAssignedForms.ts
+++ b/qualia/frontend/src/hooks/useAssignedForms.ts
@@ -1,0 +1,58 @@
+import { useQuery } from '@tanstack/react-query';
+import { getAssignedForms } from '@/services/formService';
+import type { AssignedForm } from '@/services/formService';
+import type { ApiError } from '@/lib/axios';
+
+/**
+ * TanStack Query hook for fetching assigned forms
+ *
+ * Fetches the list of forms assigned to the current user (reviewer).
+ * Returns only active, published forms that have not been submitted yet.
+ *
+ * @example
+ * ```tsx
+ * const { data, isLoading, isError, error, refetch } = useAssignedForms({
+ *   onSuccess: (data) => {
+ *     console.log('Assigned forms loaded:', data.length);
+ *   },
+ *   onError: (error) => {
+ *     console.error('Failed to load assigned forms:', error.message);
+ *     toast.error(error.message);
+ *   }
+ * });
+ *
+ * // Access the data
+ * if (isLoading) return <Spinner />;
+ * if (isError) return <ErrorMessage message={error.message} />;
+ * 
+ * return (
+ *   <div>
+ *     <h2>My Assigned Forms ({data?.length || 0})</h2>
+ *     {data?.map(form => (
+ *       <div key={form.id}>
+ *         <h3>{form.title}</h3>
+ *         <p>{form.description}</p>
+ *         <p>Deadline: {form.submission_deadline}</p>
+ *         <p>Status: {form.submission_status || 'Not started'}</p>
+ *       </div>
+ *     ))}
+ *   </div>
+ * );
+ * ```
+ */
+export const useAssignedForms = (options?: {
+  onSuccess?: (data: AssignedForm[]) => void;
+  onError?: (error: ApiError) => void;
+  enabled?: boolean; // Allow manual control of when the query runs
+}) => {
+  return useQuery<AssignedForm[], ApiError>({
+    queryKey: ['assignedForms'], // Query key for caching and invalidation
+    queryFn: () => getAssignedForms(),
+    onSuccess: options?.onSuccess,
+    onError: options?.onError,
+    enabled: options?.enabled, // Defaults to true if not specified
+    // Query will automatically retry 3 times (from global config in queryClient.ts)
+    // Data is considered fresh for 5 minutes (from global config)
+    // Query will refetch on window focus in production (from global config)
+  });
+};

--- a/qualia/frontend/src/hooks/useAssignedForms.ts
+++ b/qualia/frontend/src/hooks/useAssignedForms.ts
@@ -14,6 +14,13 @@ import { getUserFromToken } from '@/lib/jwt';
  * The query key is automatically scoped to the current user ID extracted from
  * the JWT token, ensuring that different users don't share cached data.
  *
+ * **Authentication Required**: This hook automatically disables the query when
+ * no valid JWT token is present, preventing unauthenticated requests. The query
+ * will only execute when a user ID can be extracted from the token's `sub` claim.
+ *
+ * @param options.enabled - Optional manual control to disable the query. Defaults to true,
+ *                          but the query will still be disabled if no valid user ID exists.
+ *
  * @example
  * ```tsx
  * const { data, isLoading, isError, error, refetch } = useAssignedForms();
@@ -43,12 +50,16 @@ export const useAssignedForms = (options?: {
   // Get current user ID from JWT token to scope the cache key
   // This ensures each user's assigned forms are cached separately
   const user = getUserFromToken();
-  const userId = user?.sub || 'anonymous';
+  const userId = user?.sub;
+
+  // Only run the query if we have a valid user ID AND the enabled option allows it
+  // This prevents unauthenticated requests and cache-sharing issues
+  const isEnabled = options?.enabled !== false && !!userId;
 
   return useQuery<AssignedForm[], ApiError>({
     queryKey: ['assignedForms', userId], // Scoped to user ID to prevent cache sharing between users
     queryFn: () => getAssignedForms(),
-    enabled: options?.enabled, // Defaults to true if not specified
+    enabled: isEnabled, // Only fetch when authenticated and not explicitly disabled
     // Query will automatically retry 3 times (from global config in queryClient.ts)
     // Data is considered fresh for 5 minutes (from global config)
     // Query will refetch on window focus in production (from global config)

--- a/qualia/frontend/src/hooks/useAssignedForms.ts
+++ b/qualia/frontend/src/hooks/useAssignedForms.ts
@@ -8,7 +8,8 @@ import { getUserFromToken } from '@/lib/jwt';
  * TanStack Query hook for fetching assigned forms
  *
  * Fetches the list of forms assigned to the current user (reviewer).
- * Returns only active, published forms that have not been submitted yet.
+ * Returns only active, published forms that have not been submitted yet
+ * (filtering is performed server-side by the backend API).
  *
  * The query key is automatically scoped to the current user ID extracted from
  * the JWT token, ensuring that different users don't share cached data.

--- a/qualia/frontend/src/hooks/useAssignedForms.ts
+++ b/qualia/frontend/src/hooks/useAssignedForms.ts
@@ -2,6 +2,7 @@ import { useQuery } from '@tanstack/react-query';
 import { getAssignedForms } from '@/services/formService';
 import type { AssignedForm } from '@/services/formService';
 import type { ApiError } from '@/lib/axios';
+import { getUserFromToken } from '@/lib/jwt';
 
 /**
  * TanStack Query hook for fetching assigned forms
@@ -9,22 +10,17 @@ import type { ApiError } from '@/lib/axios';
  * Fetches the list of forms assigned to the current user (reviewer).
  * Returns only active, published forms that have not been submitted yet.
  *
+ * The query key is automatically scoped to the current user ID extracted from
+ * the JWT token, ensuring that different users don't share cached data.
+ *
  * @example
  * ```tsx
- * const { data, isLoading, isError, error, refetch } = useAssignedForms({
- *   onSuccess: (data) => {
- *     console.log('Assigned forms loaded:', data.length);
- *   },
- *   onError: (error) => {
- *     console.error('Failed to load assigned forms:', error.message);
- *     toast.error(error.message);
- *   }
- * });
+ * const { data, isLoading, isError, error, refetch } = useAssignedForms();
  *
  * // Access the data
  * if (isLoading) return <Spinner />;
  * if (isError) return <ErrorMessage message={error.message} />;
- * 
+ *
  * return (
  *   <div>
  *     <h2>My Assigned Forms ({data?.length || 0})</h2>
@@ -41,15 +37,16 @@ import type { ApiError } from '@/lib/axios';
  * ```
  */
 export const useAssignedForms = (options?: {
-  onSuccess?: (data: AssignedForm[]) => void;
-  onError?: (error: ApiError) => void;
   enabled?: boolean; // Allow manual control of when the query runs
 }) => {
+  // Get current user ID from JWT token to scope the cache key
+  // This ensures each user's assigned forms are cached separately
+  const user = getUserFromToken();
+  const userId = user?.sub || 'anonymous';
+
   return useQuery<AssignedForm[], ApiError>({
-    queryKey: ['assignedForms'], // Query key for caching and invalidation
+    queryKey: ['assignedForms', userId], // Scoped to user ID to prevent cache sharing between users
     queryFn: () => getAssignedForms(),
-    onSuccess: options?.onSuccess,
-    onError: options?.onError,
     enabled: options?.enabled, // Defaults to true if not specified
     // Query will automatically retry 3 times (from global config in queryClient.ts)
     // Data is considered fresh for 5 minutes (from global config)

--- a/qualia/frontend/src/hooks/useAssignedForms.ts
+++ b/qualia/frontend/src/hooks/useAssignedForms.ts
@@ -56,7 +56,7 @@ export const useAssignedForms = (options?: {
   // Defensively validate that userId is a non-empty string
   // This prevents issues if localStorage is corrupted/tampered and sub claim is non-string
   const userId = typeof user?.sub === 'string' && user.sub.trim() !== ''
-    ? user.sub
+    ? user.sub.trim()
     : undefined;
 
   // Only run the query if we have a valid user ID AND the enabled option allows it

--- a/qualia/frontend/src/hooks/useAssignedForms.ts
+++ b/qualia/frontend/src/hooks/useAssignedForms.ts
@@ -52,7 +52,12 @@ export const useAssignedForms = (options?: {
   // Get current user ID from JWT token to scope the cache key
   // This ensures each user's assigned forms are cached separately
   const user = getUserFromToken();
-  const userId = user?.sub;
+
+  // Defensively validate that userId is a non-empty string
+  // This prevents issues if localStorage is corrupted/tampered and sub claim is non-string
+  const userId = typeof user?.sub === 'string' && user.sub.trim() !== ''
+    ? user.sub
+    : undefined;
 
   // Only run the query if we have a valid user ID AND the enabled option allows it
   // This prevents unauthenticated requests and cache-sharing issues

--- a/qualia/frontend/src/hooks/useAssignedForms.ts
+++ b/qualia/frontend/src/hooks/useAssignedForms.ts
@@ -15,8 +15,10 @@ import { getUserFromToken } from '@/lib/jwt';
  * the JWT token, ensuring that different users don't share cached data.
  *
  * **Authentication Required**: This hook automatically disables the query when
- * no valid JWT token is present, preventing unauthenticated requests. The query
+ * no JWT token is present or when the token cannot be decoded. The query
  * will only execute when a user ID can be extracted from the token's `sub` claim.
+ * Note: This does not validate token expiration - expired tokens will still trigger
+ * the query, and the backend is responsible for rejecting expired tokens.
  *
  * @param options.enabled - Optional manual control to disable the query. Defaults to true,
  *                          but the query will still be disabled if no valid user ID exists.

--- a/qualia/frontend/src/hooks/useLogout.ts
+++ b/qualia/frontend/src/hooks/useLogout.ts
@@ -1,11 +1,11 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { logout } from '@/services/authService';
 
 /**
  * TanStack Query mutation hook for user logout
  *
- * Clears authentication tokens from localStorage and optionally
- * performs any additional cleanup or API calls needed during logout.
+ * Clears authentication tokens from localStorage and invalidates all
+ * TanStack Query caches to prevent data leakage between user sessions.
  *
  * @example
  * ```tsx
@@ -27,9 +27,17 @@ export const useLogout = (options?: {
   onSuccess?: () => void;
   onError?: (error: unknown) => void;
 }) => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: () => logout(),
-    onSuccess: options?.onSuccess,
+    onSuccess: () => {
+      // Clear all TanStack Query caches to prevent data leakage between user sessions
+      queryClient.clear();
+
+      // Call user's onSuccess callback if provided
+      options?.onSuccess?.();
+    },
     onError: options?.onError,
     // No retry needed for logout - it's a local operation
     retry: false,

--- a/qualia/frontend/src/hooks/useLogout.ts
+++ b/qualia/frontend/src/hooks/useLogout.ts
@@ -4,7 +4,7 @@ import { logout } from '@/services/authService';
 /**
  * TanStack Query mutation hook for user logout
  *
- * Clears authentication tokens from localStorage and invalidates all
+ * Clears authentication tokens from localStorage and clears all
  * TanStack Query caches to prevent data leakage between user sessions.
  *
  * @example

--- a/qualia/frontend/src/hooks/useLogout.ts
+++ b/qualia/frontend/src/hooks/useLogout.ts
@@ -4,8 +4,12 @@ import { logout } from '@/services/authService';
 /**
  * TanStack Query mutation hook for user logout
  *
- * Clears authentication tokens from localStorage and clears all
- * TanStack Query caches to prevent data leakage between user sessions.
+ * Clears authentication tokens from localStorage, cancels all in-flight queries,
+ * and clears all TanStack Query caches to prevent data leakage between user sessions.
+ *
+ * Security: Cancelling in-flight queries before clearing ensures that requests
+ * started before logout cannot resolve and repopulate UI state/data after the
+ * session has been cleared.
  *
  * @example
  * ```tsx
@@ -31,7 +35,10 @@ export const useLogout = (options?: {
 
   return useMutation({
     mutationFn: () => logout(),
-    onSuccess: () => {
+    onSuccess: async () => {
+      // Cancel all in-flight queries to prevent them from resolving after logout
+      await queryClient.cancelQueries();
+
       // Clear all TanStack Query caches to prevent data leakage between user sessions
       queryClient.clear();
 

--- a/qualia/frontend/src/services/formService.ts
+++ b/qualia/frontend/src/services/formService.ts
@@ -57,9 +57,55 @@ export const createFormCycle = async (data: CreateFormCycleRequest): Promise<Cre
 
   // Debug logging in development
   if (import.meta.env.DEV) {
-    console.log('Create form cycle response:', { 
+    console.log('Create form cycle response:', {
       id: response.data.id,
       status: response.data.status
+    });
+  }
+
+  return response.data;
+};
+
+/**
+ * Assigned form item from the API
+ */
+export interface AssignedForm {
+  id: string;
+  title: string;
+  description: string | null;
+  submission_deadline: string; // ISO 8601 format with timezone
+  submission_status: string | null;
+}
+
+/**
+ * Get forms assigned to the current user (reviewer)
+ * @returns Promise with array of assigned forms
+ * @throws When the API request fails, throws an error object produced by apiClient interceptors
+ *         (see ApiError interface in @/lib/axios) with properties: status?, message, data?, originalError.
+ *         This includes network errors, authentication errors, and server errors.
+ *
+ * @example
+ * ```typescript
+ * const assignedForms = await getAssignedForms();
+ * console.log(assignedForms.length); // Number of assigned forms
+ * console.log(assignedForms[0].title); // "Q2 2026 QA Cycle"
+ * console.log(assignedForms[0].submission_status); // "draft" or "in_progress" or null
+ * ```
+ */
+export const getAssignedForms = async (): Promise<AssignedForm[]> => {
+  // Debug logging in development
+  if (import.meta.env.DEV) {
+    console.log('Get assigned forms request:', {
+      endpoint: '/forms/assigned'
+    });
+  }
+
+  const response = await apiClient.get<AssignedForm[]>('/forms/assigned');
+
+  // Debug logging in development
+  if (import.meta.env.DEV) {
+    console.log('Get assigned forms response:', {
+      count: response.data.length
     });
   }
 

--- a/qualia/frontend/src/services/formService.ts
+++ b/qualia/frontend/src/services/formService.ts
@@ -79,6 +79,7 @@ export interface AssignedForm {
 
 /**
  * Get forms assigned to the current user (reviewer)
+ * @param signal - Optional AbortSignal to cancel the request (provided by TanStack Query)
  * @returns Promise with array of assigned forms
  * @throws When the API request fails, throws an error object produced by apiClient interceptors
  *         (see ApiError interface in @/lib/axios) with properties: status?, message, data?, originalError.
@@ -92,7 +93,7 @@ export interface AssignedForm {
  * console.log(assignedForms[0].submission_status); // "draft" or "in_progress" or null
  * ```
  */
-export const getAssignedForms = async (): Promise<AssignedForm[]> => {
+export const getAssignedForms = async (signal?: AbortSignal): Promise<AssignedForm[]> => {
   // Debug logging in development
   if (import.meta.env.DEV) {
     console.log('Get assigned forms request:', {
@@ -100,7 +101,9 @@ export const getAssignedForms = async (): Promise<AssignedForm[]> => {
     });
   }
 
-  const response = await apiClient.get<AssignedForm[]>('/forms/assigned');
+  const response = await apiClient.get<AssignedForm[]>('/forms/assigned', {
+    signal,
+  });
 
   // Debug logging in development
   if (import.meta.env.DEV) {


### PR DESCRIPTION
# Add Get Assigned Forms Endpoint Integration

## Summary
Added frontend integration for the `/forms/assigned` API endpoint, allowing reviewers to fetch forms assigned to them. This includes a new service function and a TanStack Query hook for efficient data fetching and caching.

## Changes

### 📋 Form Service (`src/services/formService.ts`)
- Added `AssignedForm` interface to define the shape of assigned form data
  - Includes: `id`, `title`, `description`, `submission_deadline`, `submission_status`
- Added `getAssignedForms()` function to fetch forms assigned to the current user
  - Makes GET request to `/forms/assigned` endpoint
  - Returns array of `AssignedForm` objects
  - Includes development logging for debugging
  - Proper error handling via apiClient interceptors

### 🎣 Custom Hook (`src/hooks/useAssignedForms.ts`)
- Created `useAssignedForms` hook using TanStack Query
  - Automatically scoped to current user ID from JWT token
  - Prevents cache sharing between different users
  - Optional `enabled` parameter for manual query control
  - Returns assigned forms with loading/error states
  - Comprehensive JSDoc documentation with usage examples

## Technical Details
- **Endpoint**: `GET /forms/assigned`
- **Caching**: Query key scoped to user ID (`['assignedForms', userId]`)
- **Authentication**: Uses existing JWT token from auth context
- **Type Safety**: Full TypeScript interfaces for request/response
- **Error Handling**: Leverages global apiClient error interceptors

## Backend Integration
This PR integrates with the backend endpoint that returns:
- Only active, published forms
- Forms where the user is assigned as a reviewer
- Forms that haven't been submitted yet (server-side filtering)

## Testing Recommendations
- [ ] Verify hook fetches assigned forms for authenticated users
- [ ] Test query caching works correctly per user
- [ ] Verify error handling for network failures
- [ ] Test loading states display correctly
- [ ] Verify data refetches on window focus (production)
- [ ] Test `enabled` option works for conditional fetching
- [ ] Verify user ID scoping prevents cache leaks between users