### PR TITLE
feat: add the get form submissions endpoint

### DIFF
--- a/qualia/frontend/src/hooks/useFormSubmissions.ts
+++ b/qualia/frontend/src/hooks/useFormSubmissions.ts
@@ -1,6 +1,6 @@
 import { useQuery } from '@tanstack/react-query';
-import { getFormSubmissions } from '@/services/formService';
-import type { FormSubmission, SubmissionSort, SubmissionStatus } from '@/services/formService';
+import { getFormSubmissions, SubmissionSort, SubmissionStatus } from '@/services/formService';
+import type { FormSubmission } from '@/services/formService';
 import type { ApiError } from '@/lib/axios';
 
 /**

--- a/qualia/frontend/src/hooks/useFormSubmissions.ts
+++ b/qualia/frontend/src/hooks/useFormSubmissions.ts
@@ -18,7 +18,7 @@ import type { ApiError } from '@/lib/axios';
  *
  * @param formCycleId - The ID of the form cycle to fetch submissions for
  * @param options.status - Optional filter to show only submissions with a specific status
- * @param options.sort - Optional sort order for submissions (default: submitted_at_asc)
+ * @param options.sort - Optional sort order for submissions
  * @param options.enabled - Optional manual control to disable the query. Defaults to true
  *                          when formCycleId is provided.
  *

--- a/qualia/frontend/src/hooks/useFormSubmissions.ts
+++ b/qualia/frontend/src/hooks/useFormSubmissions.ts
@@ -76,7 +76,7 @@ export const useFormSubmissions = (
     queryKey: ['formSubmissions', formCycleId, options?.status, options?.sort],
     queryFn: ({ signal }) => getFormSubmissions(formCycleId, {
       status: options?.status,
-      sort: options?.sort(),
+      sort: options?.sort,
       signal,
     }),
     enabled: isEnabled,

--- a/qualia/frontend/src/hooks/useFormSubmissions.ts
+++ b/qualia/frontend/src/hooks/useFormSubmissions.ts
@@ -1,0 +1,87 @@
+import { useQuery } from '@tanstack/react-query';
+import { getFormSubmissions } from '@/services/formService';
+import type { FormSubmission, SubmissionSort, SubmissionStatus } from '@/services/formService';
+import type { ApiError } from '@/lib/axios';
+
+/**
+ * TanStack Query hook for fetching form submissions
+ *
+ * Fetches the list of submissions for a specific form cycle (admin only).
+ * This endpoint requires admin authentication and will return 403 for non-admin users.
+ *
+ * The query key is automatically scoped to the form cycle ID and filter parameters,
+ * ensuring proper cache management when filters change.
+ *
+ * **Authentication & Authorization Required**: This hook requires a valid JWT token
+ * with admin privileges. The query will execute even without authentication, but the
+ * backend will reject unauthorized requests with 401/403 errors.
+ *
+ * @param formCycleId - The ID of the form cycle to fetch submissions for
+ * @param options.status - Optional filter to show only submissions with a specific status
+ * @param options.sort - Optional sort order for submissions (default: submitted_at_asc)
+ * @param options.enabled - Optional manual control to disable the query. Defaults to true
+ *                          when formCycleId is provided.
+ *
+ * @returns Query result with standard TanStack Query properties
+ *          - All standard TanStack Query properties (data, isLoading, isError, error, refetch, etc.)
+ *
+ * @example
+ * ```tsx
+ * const { data, isLoading, isError, error, refetch } = useFormSubmissions(
+ *   "550e8400-e29b-41d4-a716-446655440000"
+ * );
+ *
+ * if (isLoading) return <Spinner />;
+ * if (isError) return <ErrorMessage message={error.message} />;
+ *
+ * return (
+ *   <div>
+ *     <h2>Submissions ({data?.length || 0})</h2>
+ *     {data?.map(submission => (
+ *       <div key={submission.id}>
+ *         <p>Reviewer: {submission.reviewer_email}</p>
+ *         <p>Status: {submission.status}</p>
+ *         <p>Submitted: {submission.submitted_at || 'Not submitted'}</p>
+ *       </div>
+ *     ))}
+ *   </div>
+ * );
+ * ```
+ *
+ * @example
+ * ```tsx
+ * // With filters
+ * const { data } = useFormSubmissions(
+ *   "550e8400-e29b-41d4-a716-446655440000",
+ *   {
+ *     status: SubmissionStatus.SUBMITTED,
+ *     sort: SubmissionSort.SUBMITTED_AT_DESC
+ *   }
+ * );
+ * ```
+ */
+export const useFormSubmissions = (
+  formCycleId: string,
+  options?: {
+    status?: SubmissionStatus;
+    sort?: SubmissionSort;
+    enabled?: boolean;
+  }
+) => {
+  // Only run the query if we have a valid form cycle ID AND the enabled option allows it
+  const isEnabled = options?.enabled !== false && !!formCycleId;
+
+  return useQuery<FormSubmission[], ApiError>({
+    // Query key includes form cycle ID and filter parameters for proper cache scoping
+    queryKey: ['formSubmissions', formCycleId, options?.status, options?.sort],
+    queryFn: ({ signal }) => getFormSubmissions(formCycleId, {
+      status: options?.status,
+      sort: options?.sort(),
+      signal,
+    }),
+    enabled: isEnabled,
+    // Query will automatically retry 3 times (from global config in queryClient.ts)
+    // Data is considered fresh for 5 minutes (from global config)
+    // Query will refetch on window focus in production (from global config)
+  });
+};

--- a/qualia/frontend/src/services/formService.ts
+++ b/qualia/frontend/src/services/formService.ts
@@ -186,3 +186,106 @@ export const getAssignedForms = async (
 
   return response.data;
 };
+
+/**
+ * Form submission item from the API (admin view)
+ */
+export interface FormSubmission {
+  id: string;
+  status: string;
+  started_at: string | null; // ISO 8601 format with timezone
+  submitted_at: string | null; // ISO 8601 format with timezone
+  reviewer_id: string;
+  reviewer_email: string | null;
+}
+
+/**
+ * Submission sort options for the API
+ */
+export const SubmissionSort = {
+  STARTED_AT_ASC: "started_at_asc",
+  STARTED_AT_DESC: "started_at_desc",
+  SUBMITTED_AT_ASC: "submitted_at_asc",
+  SUBMITTED_AT_DESC: "submitted_at_desc",
+} as const;
+
+export type SubmissionSort = typeof SubmissionSort[keyof typeof SubmissionSort];
+
+/**
+ * Submission status values
+ */
+export const SubmissionStatus = {
+  STARTED: "started",
+  SUBMITTED: "submitted",
+  DRAFT: "draft",
+} as const;
+
+export type SubmissionStatus = typeof SubmissionStatus[keyof typeof SubmissionStatus];
+
+/**
+ * Get submissions for a specific form cycle (admin only)
+ * @param formCycleId - The ID of the form cycle
+ * @param options - Optional query parameters (status, sort, signal)
+ * @returns Promise with array of form submissions
+ * @throws When the API request fails, throws an error object produced by apiClient interceptors
+ *         (see ApiError interface in @/lib/axios) with properties: status?, message, data?, originalError.
+ *         This includes network errors, authentication errors, authorization errors, and server errors.
+ *
+ * @example
+ * ```typescript
+ * const submissions = await getFormSubmissions("550e8400-e29b-41d4-a716-446655440000");
+ * console.log(submissions.length); // Number of submissions
+ * console.log(submissions[0].status); // "submitted" or "started" or "draft"
+ * console.log(submissions[0].reviewer_email); // "reviewer@example.com"
+ *
+ * // With filters
+ * const submittedOnly = await getFormSubmissions(
+ *   "550e8400-e29b-41d4-a716-446655440000",
+ *   { status: SubmissionStatus.SUBMITTED, sort: SubmissionSort.SUBMITTED_AT_DESC }
+ * );
+ * ```
+ */
+export const getFormSubmissions = async (
+  formCycleId: string,
+  options?: {
+    status?: SubmissionStatus;
+    sort?: SubmissionSort;
+    signal?: AbortSignal;
+  },
+): Promise<FormSubmission[]> => {
+  // Debug logging in development
+  if (import.meta.env.DEV) {
+    console.log("Get form submissions request:", {
+      endpoint: `/forms/${formCycleId}/submissions`,
+      formCycleId: formCycleId,
+      status: options?.status,
+      sort: options?.sort,
+    });
+  }
+
+  // Build query parameters
+  const params: Record<string, string> = {};
+  if (options?.status) {
+    params.status = options.status;
+  }
+  if (options?.sort) {
+    params.sort = options.sort;
+  }
+
+  const response = await apiClient.get<FormSubmission[]>(
+    `/form/${formCycleId}/submissions`,
+    {
+      params,
+      signal: options?.signal,
+    },
+  );
+
+  // Debug logging in development
+  if (import.meta.env.DEV) {
+    console.log("Get form submissions response:", {
+      count: response.data.length,
+    });
+  }
+
+  return response.data;
+};

--- a/qualia/frontend/src/services/formService.ts
+++ b/qualia/frontend/src/services/formService.ts
@@ -188,11 +188,22 @@ export const getAssignedForms = async (
 };
 
 /**
+ * Submission status values
+ */
+export const SubmissionStatus = {
+  STARTED: "started",
+  SUBMITTED: "submitted",
+  DRAFT: "draft",
+} as const;
+
+export type SubmissionStatus = typeof SubmissionStatus[keyof typeof SubmissionStatus];
+
+/**
  * Form submission item from the API (admin view)
  */
 export interface FormSubmission {
   id: string;
-  status: string;
+  status: SubmissionStatus;
   started_at: string | null; // ISO 8601 format with timezone
   submitted_at: string | null; // ISO 8601 format with timezone
   reviewer_id: string;
@@ -210,17 +221,6 @@ export const SubmissionSort = {
 } as const;
 
 export type SubmissionSort = typeof SubmissionSort[keyof typeof SubmissionSort];
-
-/**
- * Submission status values
- */
-export const SubmissionStatus = {
-  STARTED: "started",
-  SUBMITTED: "submitted",
-  DRAFT: "draft",
-} as const;
-
-export type SubmissionStatus = typeof SubmissionStatus[keyof typeof SubmissionStatus];
 
 /**
  * Get submissions for a specific form cycle (admin only)

--- a/qualia/frontend/src/services/formService.ts
+++ b/qualia/frontend/src/services/formService.ts
@@ -273,7 +273,7 @@ export const getFormSubmissions = async (
   }
 
   const response = await apiClient.get<FormSubmission[]>(
-    `/form/${formCycleId}/submissions`,
+    `/forms/${formCycleId}/submissions`,
     {
       params,
       signal: options?.signal,


### PR DESCRIPTION
# Add Form Submissions Endpoint

## Summary
This PR adds functionality for admins to fetch and view submissions for a specific form cycle through a new API integration.

## Changes

### 📋 Form Submissions Service (`src/services/formService.ts`)
- Added `getFormSubmissions()` function to fetch submissions for a specific form cycle
- Endpoint: `GET /forms/{formCycleId}/submissions`
- **Admin-only**: Requires admin authentication (403 for non-admin users)
- Supports optional filtering and sorting:
  - Filter by status: `started`, `submitted`, `draft`
  - Sort by: `started_at_asc`, `started_at_desc`, `submitted_at_asc`, `submitted_at_desc`
- Returns submission details:
  - `id` - Submission ID
  - `status` - Submission status (started/submitted/draft)
  - `started_at` - When the reviewer started the form
  - `submitted_at` - When the reviewer submitted the form
  - `reviewer_id` - ID of the assigned reviewer
  - `reviewer_email` - Email of the assigned reviewer
- Added TypeScript types:
  - `FormSubmission` interface
  - `SubmissionSort` enum for sort options
  - `SubmissionStatus` enum for status values
- Includes debug logging in development mode

### 🎣 Form Submissions Hook (`src/hooks/useFormSubmissions.ts`)
- Created `useFormSubmissions()` TanStack Query hook
- Wraps `getFormSubmissions()` with automatic caching and query management
- Features:
  - Automatic query key scoping by form cycle ID and filter parameters
  - Built-in loading and error states
  - Optional manual enable/disable control
  - Automatic retries (3 attempts from global config)
  - 5-minute cache freshness (from global config)
  - Auto-refetch on window focus in production
  - AbortSignal support for request cancellation
- Well-documented with JSDoc including usage examples

## Why These Changes?

- **Admin Visibility**: Allows admins to view all submissions for a form cycle
- **Filtering & Sorting**: Admins can filter by submission status and sort by various criteria
- **Better UX**: TanStack Query integration provides loading states, error handling, and automatic caching
- **Type Safety**: Full TypeScript support with proper interfaces and enums
- **Developer Experience**: Comprehensive documentation and debug logging

## Technical Details

- **API Endpoint**: `GET /forms/{formCycleId}/submissions`
- **Authentication**: Requires admin role (JWT tokens from localStorage)
- **Query Parameters**:
  - `status` (optional): Filter by submission status
  - `sort` (optional): Sort order for results
- **Caching Strategy**: Query key includes form cycle ID and filter params for proper cache invalidation

## Testing Recommendations

- [ ] Verify submissions are fetched when logged in as an admin
- [ ] Test loading state appears while fetching submissions
- [ ] Test error handling when API returns errors
- [ ] Verify 403 errors occur for non-admin users
- [ ] Test filtering by different status values
- [ ] Test different sort options
- [ ] Verify cache invalidation works when filters change
- [ ] Test AbortSignal cancellation when component unmounts
- [ ] Check debug logs in development mode