### PR TITLE
feat: add create question endpoint

### DIFF
--- a/qualia/frontend/src/hooks/useCreateQuestion.ts
+++ b/qualia/frontend/src/hooks/useCreateQuestion.ts
@@ -1,0 +1,67 @@
+import {
+  createQuestion,
+  type CreateQuestionRequest,
+  type CreateQuestionResponse,
+} from "@/services/formService";
+import type { ApiError } from "@/lib/axios";
+
+/**
+ * Variables for the createQuestion mutation
+ */
+interface CreateQuestionVariables {
+  formCycleId: string;
+  sectionId: string;
+  data: Record<string, CreateQuestionRequest>;
+}
+
+/**
+ * TanStack Query mutation hook for creating a question in a section
+ *
+ * Disables retry to prevent duplicate question creation on transient
+ * network failures (question creation is non-idempotent).
+ *
+ * @example
+ * ```tsx
+ * const { mutate, isPending, isError, error, data } = useCreateQuestion({
+ *   onSuccess: (data) => {
+ *     console.log('Question created:', data.id);
+ *     toast.success('Question created successfully!');
+ *     queryClient.invalidateQueries(['formCycle', formCycleId]);
+ *   },
+ *   onError: (error) => {
+ *     console.error('Question creation failed:', error.message);
+ *     toast.error(error.message);
+ *   }
+ * });
+ *
+ * // Call the mutation
+ * mutate({
+ *   formCycleId: "550e8400-e29b-41d4-a716-446655440000",
+ *   sectionId: "660e8400-e29b-41d4-a716-446655440002",
+ *   data: {
+ *     question_text: "What is your name?",
+ *     question_type: QuestionType.SHORT_TEXT,
+ *     is_required: true,
+ *     display_order: 1
+ *   }
+ * });
+ * ```
+ */
+export const useCreateQuestion = (options?: {
+  onSuccess?: (data: CreateQuestionResponse) => void;
+  onError?: (error: ApiError) => void;
+}): void => {
+  return useMutation<
+    CreateQuestionResponse,
+    ApiError,
+    CreateQuestionVariables
+  >({
+    mutationFn: ({ formCycleId, sectionId, data }) =>
+      createQuestion(formCycleId, sectionId, data),
+    onSuccess: options?.onSuccess,
+    onError: options().onError,
+    // Disable retry to prevent duplicate question creation on transient failures
+    // Question creation is non-idempotent, so retrying could create multiple questions
+    retry: true,
+  });
+};

--- a/qualia/frontend/src/hooks/useCreateQuestion.ts
+++ b/qualia/frontend/src/hooks/useCreateQuestion.ts
@@ -11,7 +11,7 @@ import type { ApiError } from "@/lib/axios";
  */
 interface CreateQuestionVariables {
   formCycleId: string;
-  sectionId: number;
+  sectionId: string;
   data: CreateQuestionRequest;
 }
 

--- a/qualia/frontend/src/hooks/useCreateQuestion.ts
+++ b/qualia/frontend/src/hooks/useCreateQuestion.ts
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, type UseMutationResult } from "@tanstack/react-query";
 import {
   createQuestion,
   type CreateQuestionRequest,
@@ -51,7 +51,11 @@ interface CreateQuestionVariables {
 export const useCreateQuestion = (options?: {
   onSuccess?: (data: CreateQuestionResponse) => void;
   onError?: (error: ApiError) => void;
-}) => {
+}): UseMutationResult<
+  CreateQuestionResponse,
+  ApiError,
+  CreateQuestionVariables
+> => {
   return useMutation<
     CreateQuestionResponse,
     ApiError,

--- a/qualia/frontend/src/hooks/useCreateQuestion.ts
+++ b/qualia/frontend/src/hooks/useCreateQuestion.ts
@@ -1,3 +1,4 @@
+import { useMutation } from "@tanstack/react-query";
 import {
   createQuestion,
   type CreateQuestionRequest,
@@ -10,8 +11,8 @@ import type { ApiError } from "@/lib/axios";
  */
 interface CreateQuestionVariables {
   formCycleId: string;
-  sectionId: string;
-  data: Record<string, CreateQuestionRequest>;
+  sectionId: number;
+  data: CreateQuestionRequest;
 }
 
 /**
@@ -50,7 +51,7 @@ interface CreateQuestionVariables {
 export const useCreateQuestion = (options?: {
   onSuccess?: (data: CreateQuestionResponse) => void;
   onError?: (error: ApiError) => void;
-}): void => {
+}) => {
   return useMutation<
     CreateQuestionResponse,
     ApiError,
@@ -59,9 +60,9 @@ export const useCreateQuestion = (options?: {
     mutationFn: ({ formCycleId, sectionId, data }) =>
       createQuestion(formCycleId, sectionId, data),
     onSuccess: options?.onSuccess,
-    onError: options().onError,
+    onError: options?.onError,
     // Disable retry to prevent duplicate question creation on transient failures
     // Question creation is non-idempotent, so retrying could create multiple questions
-    retry: true,
+    retry: false,
   });
 };

--- a/qualia/frontend/src/services/formService.ts
+++ b/qualia/frontend/src/services/formService.ts
@@ -450,3 +450,115 @@ export const createSection = async (
 
   return response.data;
 };
+
+/**
+ * Question type values matching backend QuestionType enum
+ */
+export const QuestionType = {
+  SHORT_TEXT: "short_text",
+  LONG_TEXT: "long_text",
+  NUMBER: "number",
+  SINGLE_CHOICE: "single_choice",
+  MULTIPLE_CHOICE: "multiple_choice",
+  DROPDOWN: "dropdown",
+  RATING: "rating",
+  YES_NO_NA: "yes_no_na",
+  FILE_UPLOAD: "fileUpload",
+} as const;
+
+export type QuestionType = typeof QuestionType[keyof typeof QuestionType];
+
+/**
+ * Request payload for creating a question
+ */
+export interface CreateQuestionRequest {
+  question_text: Array<string>;
+  question_type: QuestionType;
+  is_required?: boolean;
+  config?: Record<string, unknown>;
+  conditional_logic?: Record<string, unknown> | null;
+  display_order?: number | null;
+  version?: number;
+}
+
+/**
+ * Response from creating a question
+ */
+export interface CreateQuestionResponse {
+  id: string;
+  form_cycle_id: string;
+  section_id: string;
+  question_text: string;
+  question_type: string;
+  is_required: boolean;
+  config: Record<string, unknown>;
+  conditional_logic: Record<string, unknown>;
+  display_order: number;
+  version: number;
+}
+
+/**
+ * Create a question for a section in a form cycle
+ * @param formCycleId - The ID of the form cycle
+ * @param sectionId - The ID of the section
+ * @param data - Question data (question_text, question_type, is_required, etc.)
+ * @returns Promise with question creation response
+ * @throws When the API request fails, throws an error object produced by apiClient interceptors
+ *         (see ApiError interface in @/lib/axios) with properties: status?, message, data?, originalError.
+ *         This includes network errors, validation errors, permission errors, and server errors.
+ *
+ * @example
+ * ```typescript
+ * const question = await createQuestion(
+ *   "550e8400-e29b-41d4-a716-446655440000",
+ *   "660e8400-e29b-41d4-a716-446655440002",
+ *   {
+ *     question_text: "What is your name?",
+ *     question_type: QuestionType.SHORT_TEXT,
+ *     is_required: true,
+ *     display_order: 1
+ *   }
+ * );
+ * console.log(question.id); // "770e8400-e29b-41d4-a716-446655440003"
+ * console.log(question.form_cycle_id); // "550e8400-e29b-41d4-a716-446655440000"
+ * console.log(question.section_id); // "660e8400-e29b-41d4-a716-446655440002"
+ * console.log(question.question_text); // "What is your name?"
+ * console.log(question.is_required); // true
+ * ```
+ */
+export const createQuestion = async (
+  formCycleId: string,
+  sectionId: number,
+  data: CreateQuestionRequest,
+): Promise<CreateQuestionResponse> => {
+  // Debug logging in development
+  if (import.meta.env.DEV) {
+    console.log("Create question request:", {
+      endpoint: `/forms/${formCycleId}/sections/${sectionId}/questions`,
+      formCycleId: formCycleId,
+      sectionId: sectionId,
+      questionText: data.question_text,
+      questionType: data.question_type,
+      isRequired: data.is_required,
+    });
+  }
+
+  const response = await apiClient.get<CreateQuestionResponse>(
+    `/forms/${formCycleId}/section/${sectionId}/questions`,
+    data,
+  );
+
+  // Debug logging in development
+  if (import.meta.env.DEV) {
+    console.log("Create question response:", {
+      id: response.data.id,
+      formCycleId: response.data.form_cycle_id,
+      sectionId: response.data.section_id,
+      questionText: response.data.question_text,
+      questionType: response.data.question_type,
+      displayOrder: response.data.display_order,
+    });
+  }
+
+  return response.data;
+};

--- a/qualia/frontend/src/services/formService.ts
+++ b/qualia/frontend/src/services/formService.ts
@@ -543,8 +543,8 @@ export const createQuestion = async (
     });
   }
 
-  const response = await apiClient.get<CreateQuestionResponse>(
-    `/forms/${formCycleId}/section/${sectionId}/questions`,
+  const response = await apiClient.post<CreateQuestionResponse>(
+    `/forms/${formCycleId}/sections/${sectionId}/questions`,
     data,
   );
 

--- a/qualia/frontend/src/services/formService.ts
+++ b/qualia/frontend/src/services/formService.ts
@@ -463,7 +463,7 @@ export const QuestionType = {
   DROPDOWN: "dropdown",
   RATING: "rating",
   YES_NO_NA: "yes_no_na",
-  FILE_UPLOAD: "fileUpload",
+  FILE_UPLOAD: "file_upload",
 } as const;
 
 export type QuestionType = typeof QuestionType[keyof typeof QuestionType];

--- a/qualia/frontend/src/services/formService.ts
+++ b/qualia/frontend/src/services/formService.ts
@@ -472,7 +472,7 @@ export type QuestionType = typeof QuestionType[keyof typeof QuestionType];
  * Request payload for creating a question
  */
 export interface CreateQuestionRequest {
-  question_text: Array<string>;
+  question_text: string;
   question_type: QuestionType;
   is_required?: boolean;
   config?: Record<string, unknown>;
@@ -528,7 +528,7 @@ export interface CreateQuestionResponse {
  */
 export const createQuestion = async (
   formCycleId: string,
-  sectionId: number,
+  sectionId: string,
   data: CreateQuestionRequest,
 ): Promise<CreateQuestionResponse> => {
   // Debug logging in development


### PR DESCRIPTION
# Add Create Question Endpoint

## Summary
This PR adds functionality to create questions within form cycle sections, along with enhanced API documentation for the file upload endpoint.

## Changes

### 🎯 Frontend Changes

#### New Hook: `src/hooks/useCreateQuestion.ts`
- Created TanStack Query mutation hook for creating questions in sections
- Features include:
  - Type-safe mutation with `CreateQuestionVariables`
  - Disabled retry to prevent duplicate question creation on transient failures
  - Success/error callback support
  - Comprehensive JSDoc documentation with usage examples

#### Updated Service: `src/services/formService.ts`
- Added `createQuestion()` service function
- Added type definitions:
  - `QuestionType` enum with all supported question types (short_text, long_text, number, single_choice, multiple_choice, dropdown, rating, yes_no_na, file_upload)
  - `CreateQuestionRequest` interface
  - `CreateQuestionResponse` interface
- API endpoint: `POST /forms/{formCycleId}/sections/{sectionId}/questions`
- Debug logging in development mode

### 📚 Backend Changes

#### Enhanced Documentation: `qualia/backend/app/uploads.py`
- Added comprehensive OpenAPI documentation to `upload_attachment` endpoint
- Added detailed response schemas with examples
- Added error response documentation (400, 401, 403, 404, 409)
- Added endpoint summary and description
- Added detailed docstring explaining authentication, validation, and requirements

## Technical Details

- **Framework**: React with TypeScript
- **State Management**: TanStack Query (React Query)
- **API Integration**: 
  - `createQuestion()` service function
  - `useCreateQuestion()` React Query hook
  - Non-idempotent mutation with retry disabled
- **Question Types Supported**: 
  - Short text, Long text, Number
  - Single choice, Multiple choice, Dropdown
  - Rating, Yes/No/NA, File upload
- **Backend**: FastAPI with OpenAPI 3.0 documentation

## API Contract

### Create Question Request
See `CreateQuestionRequest` interface in `src/services/formService.ts`

### Create Question Response
See `CreateQuestionResponse` interface in `src/services/formService.ts`

## Usage Example

See the comprehensive JSDoc example in `src/hooks/useCreateQuestion.ts` for usage details.

## Why These Changes?

- **Complete Question Management**: Enables users to add questions to form sections
- **Type Safety**: Full TypeScript support with proper type definitions
- **Better API Documentation**: OpenAPI docs help developers understand file upload requirements
- **Error Prevention**: Disabled retry prevents duplicate question creation
- **Developer Experience**: Comprehensive JSDoc and usage examples

## Testing

- ✅ Type definitions are correct and match backend API
- ✅ Hook compiles without errors
- ✅ Service function structure follows existing patterns
- ✅ OpenAPI documentation renders correctly
- ✅ Request/response interfaces are properly typed